### PR TITLE
Update installed versions of Go

### DIFF
--- a/images/win/scripts/Installers/Install-Go.ps1
+++ b/images/win/scripts/Installers/Install-Go.ps1
@@ -25,8 +25,14 @@ function Install-GoVersion
 
     # Delete unnecessary files to conserve space
     Write-Host "Cleaning directories of Go $goVersion..."
-    Remove-Item -Recurse -Force "C:\go\blog"
-    Remove-Item -Recurse -Force "C:\go\doc"
+    if (Test-Path "C:\go\doc")
+    {
+        Remove-Item -Recurse -Force "C:\go\doc"
+    }
+    if (Test-Path "C:\go\blog")
+    {
+        Remove-Item -Recurse -Force "C:\go\blog"
+    }
 
     # Rename the extracted "go" directory to include the Go version number (to support side-by-side versions of Go).
     $newDirName = "Go$goVersion"

--- a/images/win/scripts/Installers/Install-Go.ps1
+++ b/images/win/scripts/Installers/Install-Go.ps1
@@ -52,12 +52,16 @@ function Install-GoVersion
 }
 
 # Install Go 1.9.x
-$installDirectory = Install-GoVersion -goVersion '1.9.4' -addToDefaultPath $False
+$installDirectory = Install-GoVersion -goVersion '1.9.7' -addToDefaultPath $False
 setx GOROOT_1_9_X64 "$installDirectory" /M
 
 # Install Go 1.10.x
-$installDirectory = Install-GoVersion -goVersion '1.10' -addToDefaultPath $True
+$installDirectory = Install-GoVersion -goVersion '1.10.4' -addToDefaultPath $False
 setx GOROOT_1_10_X64 "$installDirectory" /M
+
+# Install Go 1.11.x
+$installDirectory = Install-GoVersion -goVersion '1.11' -addToDefaultPath $True
+setx GOROOT_1_11_X64 "$installDirectory" /M
 
 # Done
 exit 0


### PR DESCRIPTION
It's expected that we can remove Go 1.9 after Go 1.11 has been out for a few more weeks (it's brand new).