### PR TITLE
Warmup dotnet sdks

### DIFF
--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -49,8 +49,4 @@ $dotnetReleases | ForEach-Object {
     }
 }
 
-#Add-MachinePathItem "C:\Program Files\dotnet"
-
-
-
-
+Add-MachinePathItem "C:\Program Files\dotnet"

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -12,44 +12,45 @@ New-Item -Path C:\Temp -Force -ItemType Directory
 
 Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases.json' -UseBasicParsing -OutFile 'dotnet-releases.json'
 $dotnetReleases = Get-Content -Path 'dotnet-releases.json' | ConvertFrom-Json
-$dotnetReleases = $dotnetReleases | Sort-Object -Property 'version-runtime'
+
+#Filtering dotnet sdk and runtime versions which does not have "-" in their name, based on naming pattern they are either preview or rc versions
+$dotnetReleases = $dotnetReleases | Where-Object {!$_."version-sdk".Contains('-') } | Sort-Object {[Version] $_."version-sdk"}
 
 Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -UseBasicParsing -OutFile 'dotnet-install.ps1'
 
-$dotnetReleases | ForEach-Object {
-    $release = $_
-    $sdkVersion = $release.'version-sdk'
-    #Filtering dotnet sdk and runtime versions which does not have "-" in their name, based on naming pattern they are either preview or rc versions
-    if(!$sdkVersion.Contains('-'))
-    {
-        .\dotnet-install.ps1 -Architecture x64 -Version $sdkVersion -InstallDir $(Join-Path -Path $env:ProgramFiles -ChildPath 'dotnet')
-    }
-}
-
-Add-MachinePathItem "C:\Program Files\dotnet"
-
-# warm up dotnet for first time experience
 $templates = @(
     'console',
-    'classlib',
     'mstest',
     'xunit',
     'web',
     'mvc',
-    'razor',
-    'angular',
-    'react',
-    'reactredux',
     'webapi'
 )
 
-$templates | ForEach-Object {
-    $template = $_
-    $projectPath = Join-Path -Path C:\temp -ChildPath $template
-    New-Item -Path $projectPath -Force -ItemType Directory
-    Set-Location -Path $projectPath
-    & $env:ProgramFiles\dotnet\dotnet.exe new $template
-    if(Test-Path -Path '.\package.json'){
-        & npm install
+$dotnetReleases | ForEach-Object {
+    $release = $_
+    $sdkVersion = $release.'version-sdk'
+    if(!(Test-Path -Path "C:\Program Files\dotnet\sdk\$sdkVersion")) {
+        Write-Host "Installing dotnet $sdkVersion"
+        .\dotnet-install.ps1 -Architecture x64 -Version $sdkVersion -InstallDir $(Join-Path -Path $env:ProgramFiles -ChildPath 'dotnet')
+        # warm up dotnet for first time experience
+        $templates | ForEach-Object {
+            $template = $_
+            $projectPath = Join-Path -Path C:\temp -ChildPath $template
+            New-Item -Path $projectPath -Force -ItemType Directory
+            Push-Location -Path $projectPath
+            & $env:ProgramFiles\dotnet\dotnet.exe new $template
+            Pop-Location
+            Remove-Item $projectPath -Force -Recurse
+        }
+    }
+    else {
+        Write-Host "Sdk version $sdkVersion already installed"
     }
 }
+
+#Add-MachinePathItem "C:\Program Files\dotnet"
+
+
+
+


### PR DESCRIPTION
Change the process to install by SDK version in order and then warmup each sdk.

Will need to figure out how to preserve the sentinel files that are persisted in the userhome under .dotnet or .nuget/packages for this to really work.