### PR TITLE
incorrect symlink

### DIFF
--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -32,7 +32,7 @@ echo "ANT_HOME=/usr/share/ant" | tee -a /etc/environment
 curl -sL http://www-eu.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.zip -o maven.zip
 unzip -d /usr/share maven.zip
 rm maven.zip
-ln -s /usr/share/apache-maven-3.5.4/bin/mvn /usr/bin/mvn
+ln -s /usr/share/apache-maven-3.5.4/bin/mvn /usr/share/maven/bin/mvn
 echo "M2_HOME=/usr/share/maven" | tee -a /etc/environment
 
 # Install Gradle


### PR DESCRIPTION
Script creates a symlink on line 35 (ln -s /usr/share/apache-maven-3.5.4/bin/mvn /usr/bin/mvn).

This is incorrect and is causing all our maven builds on Hosted Ubuntu 1604 in Azure DevOps to fail. The error in Azure DevOps is

UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Unable to locate executable file: '/usr/share/maven/bin/mvn'. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.

I've found the root cause: Script sets M2_HOME to /usr/share/maven but symlink for maven executable is create at /usr/bin/mvn.