### PR TITLE
Switching to use Azul JDKs in Linux and Windows images

### DIFF
--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -10,18 +10,18 @@ source $HELPER_SCRIPTS/document.sh
 
 DEFAULT_JDK_VERSION=8
 
-# Install Java OpenJDKs, fast
-apt-add-repository -y ppa:openjdk-r/ppa
-apt-get update
-apt-fast install -y --no-install-recommends openjdk-7-jdk openjdk-8-jdk openjdk-9-jdk openjdk-10-jdk openjdk-11-jdk
-update-alternatives --set java /usr/lib/jvm/java-"${DEFAULT_JDK_VERSION}"-openjdk-amd64/jre/bin/java
-
-echo "JAVA_HOME_7_X64=/usr/lib/jvm/java-7-openjdk-amd64" | tee -a /etc/environment
-echo "JAVA_HOME_8_X64=/usr/lib/jvm/java-8-openjdk-amd64" | tee -a /etc/environment
-echo "JAVA_HOME_9_X64=/usr/lib/jvm/java-9-openjdk-amd64" | tee -a /etc/environment
-echo "JAVA_HOME_10_X64=/usr/lib/jvm/java-10-openjdk-amd64" | tee -a /etc/environment
-echo "JAVA_HOME_11_X64=/usr/lib/jvm/java-11-openjdk-amd64" | tee -a /etc/environment
-echo "JAVA_HOME=/usr/lib/jvm/java-${DEFAULT_JDK_VERSION}-openjdk-amd64" | tee -a /etc/environment
+#Install Azul jdks
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9
+apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main"
+apt-get -q update
+apt-get -y install zulu-7-azure-jdk=7.24.0.2
+apt-get -y install zulu-8-azure-jdk=8.31.0.2
+apt-get -y install zulu-11-azure-jdk=11.2+3
+update-java-alternatives -s /usr/lib/jvm/zulu-8-azure-amd64
+echo "JAVA_HOME_7_X64=/usr/lib/jvm/zulu-7-azure-amd64" | sudo tee -a /etc/environment
+echo "JAVA_HOME_8_X64=/usr/lib/jvm/zulu-8-azure-amd64" | sudo tee -a /etc/environment
+echo "JAVA_HOME_11_X64=/usr/lib/jvm/zulu-11-azure-amd64" | sudo tee -a /etc/environment
+echo "JAVA_HOME=/usr/lib/jvm/zulu-${DEFAULT_JDK_VERSION}-azure-amd64" | tee -a /etc/environment
 echo "JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8" | tee -a /etc/environment
 
 # Install Ant
@@ -55,11 +55,9 @@ done
 
 # Document what was added to the image
 echo "Lastly, documenting what we added to the metadata file"
-DocumentInstalledItem "OpenJDK (7) ($(/usr/lib/jvm/java-7-openjdk-amd64/bin/java -showversion |& head -n 1))"
-DocumentInstalledItem "OpenJDK (8) ($(/usr/lib/jvm/java-8-openjdk-amd64/bin/java -showversion |& head -n 1))"
-DocumentInstalledItem "OpenJDK (9) ($(/usr/lib/jvm/java-9-openjdk-amd64/bin/java -showversion |& head -n 1))"
-DocumentInstalledItem "OpenJDK (10) ($(/usr/lib/jvm/java-10-openjdk-amd64/bin/java -showversion |& head -n 1))"
-DocumentInstalledItem "OpenJDK (11) ($(/usr/lib/jvm/java-11-openjdk-amd64/bin/java -showversion |& head -n 1))"
+DocumentInstalledItem "Azul JDK (7) ($(/usr/lib/jvm/zulu-7-azure-amd64/bin/java -showversion |& head -n 1))"
+DocumentInstalledItem "Azul JDK (8) ($(/usr/lib/jvm/zulu-8-azure-amd64/bin/java -showversion |& head -n 1))"
+DocumentInstalledItem "Azul JDK (11) ($(/usr/lib/jvm/zulu-11-azure-amd64/bin/java -showversion |& head -n 1))"
 DocumentInstalledItem "Ant ($(ant -version))"
 DocumentInstalledItem "Gradle ${gradle_version}"
 DocumentInstalledItem "Maven ($(mvn -version | head -n 1))"

--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -15,9 +15,9 @@ DEFAULT_JDK_VERSION=8
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9
 apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main"
 apt-get -q update
-apt-get -y install zulu-7-azure-jdk=7.24.0.2
-apt-get -y install zulu-8-azure-jdk=8.31.0.2
-apt-get -y install zulu-11-azure-jdk=11.2+3
+apt-get -y install zulu-7-azure-jdk=\*
+apt-get -y install zulu-8-azure-jdk=\*
+apt-get -y install zulu-11-azure-jdk=\*
 update-java-alternatives -s /usr/lib/jvm/zulu-8-azure-amd64
 echo "JAVA_HOME_7_X64=/usr/lib/jvm/zulu-7-azure-amd64" | tee -a /etc/environment
 echo "JAVA_HOME_8_X64=/usr/lib/jvm/zulu-8-azure-amd64" | tee -a /etc/environment

--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -11,6 +11,7 @@ source $HELPER_SCRIPTS/document.sh
 DEFAULT_JDK_VERSION=8
 
 #Install Azul jdks
+#Documentation for Azul JDK installation can be found here: https://www.azul.com/downloads/azure-only/zulu/
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9
 apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main"
 apt-get -q update
@@ -18,9 +19,9 @@ apt-get -y install zulu-7-azure-jdk=7.24.0.2
 apt-get -y install zulu-8-azure-jdk=8.31.0.2
 apt-get -y install zulu-11-azure-jdk=11.2+3
 update-java-alternatives -s /usr/lib/jvm/zulu-8-azure-amd64
-echo "JAVA_HOME_7_X64=/usr/lib/jvm/zulu-7-azure-amd64" | sudo tee -a /etc/environment
-echo "JAVA_HOME_8_X64=/usr/lib/jvm/zulu-8-azure-amd64" | sudo tee -a /etc/environment
-echo "JAVA_HOME_11_X64=/usr/lib/jvm/zulu-11-azure-amd64" | sudo tee -a /etc/environment
+echo "JAVA_HOME_7_X64=/usr/lib/jvm/zulu-7-azure-amd64" | tee -a /etc/environment
+echo "JAVA_HOME_8_X64=/usr/lib/jvm/zulu-8-azure-amd64" | tee -a /etc/environment
+echo "JAVA_HOME_11_X64=/usr/lib/jvm/zulu-11-azure-amd64" | tee -a /etc/environment
 echo "JAVA_HOME=/usr/lib/jvm/zulu-${DEFAULT_JDK_VERSION}-azure-amd64" | tee -a /etc/environment
 echo "JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8" | tee -a /etc/environment
 

--- a/images/win/scripts/Installers/Install-JavaTools.ps1
+++ b/images/win/scripts/Installers/Install-JavaTools.ps1
@@ -36,10 +36,10 @@ foreach ($pathSegment in $pathSegments)
     }
 }
 
-$java8Installs = Get-ChildItem -Path 'C:\Program Files\Java' -Filter 'jdk*8*' | Sort-Object -Property Name -Descending | Select-Object -First 1
+$java8Installs = Get-ChildItem -Path 'C:\Program Files\Java' -Filter '*azure-jdk*8*' | Sort-Object -Property Name -Descending | Select-Object -First 1
 $latestJava8Install = $java8Installs.FullName;
 
-$java11Installs = Get-ChildItem -Path 'C:\Program Files\Java' -Filter 'jdk*11*' | Sort-Object -Property Name -Descending | Select-Object -First 1
+$java11Installs = Get-ChildItem -Path 'C:\Program Files\Java' -Filter '*azure-jdk*11*' | Sort-Object -Property Name -Descending | Select-Object -First 1
 $latestJava11Install = $java11Installs.FullName;
 
 $newPath = [string]::Join(';', $newPathSegments)

--- a/images/win/scripts/Installers/Install-JavaTools.ps1
+++ b/images/win/scripts/Installers/Install-JavaTools.ps1
@@ -52,8 +52,9 @@ setx JAVA_HOME_8_X64 $latestJava8Install /M
 setx JAVA_HOME_11_X64 $latestJava11Install /M
 
 #Install Java Tools
-choco install ant -y
-choco install maven -y
+#Force chocolatey to ignore dependencies on Maven and Ant or else they will download Oracle jdk8
+choco install ant -y -i
+choco install maven -y -i
 choco install gradle -y
 
 #Move maven variables to Machine, they may not be in the environment for this script so we need to read them from the registry.

--- a/images/win/scripts/Installers/Install-JavaTools.ps1
+++ b/images/win/scripts/Installers/Install-JavaTools.ps1
@@ -4,13 +4,26 @@
 ##  Desc:  Install various JDKs and java tools
 ################################################################################
 
-#Installing Both x86 and x64 versions of Java
-choco install jdk8 -params "both=true" -y
+## Downloading azul jdks
+$azulJDK7Uri = 'https://repos.azul.com/azure-only/zulu/packages/zulu-7/7u191/zulu-7-azure-jdk_7.24.0.2-7.0.191-win_x64.zip'
+$azulJDK8Uri = 'https://repos.azul.com/azure-only/zulu/packages/zulu-8/8u181/zulu-8-azure-jdk_8.31.0.2-8.0.181-win_x64.zip'
+$azulJDK11Uri = 'https://repos.azul.com/azure-only/zulu/packages/zulu-11/11.0.1/zulu-11-azure-jdk_11.2.3-11.0.1-win_x64.zip'
 
-choco install jdk11 -y
-choco install ant -y
-choco install maven -y
-choco install gradle -y
+cd $env:TEMP
+
+Invoke-WebRequest -UseBasicParsing -Uri $azulJDK7Uri -OutFile azulJDK7.zip
+Invoke-WebRequest -UseBasicParsing -Uri $azulJDK8Uri -OutFile azulJDK8.zip
+Invoke-WebRequest -UseBasicParsing -Uri $azulJDK11Uri -OutFile azulJDK11.zip
+
+# Expand the zips
+Expand-Archive -Path azulJDK7.zip -DestinationPath "C:\Program Files\Java\" -Force
+Expand-Archive -Path azulJDK8.zip -DestinationPath "C:\Program Files\Java\" -Force
+Expand-Archive -Path azulJDK11.zip -DestinationPath "C:\Program Files\Java\" -Force
+
+# Deleting zip folders
+Remove-Item -Recurse -Force azulJDK7.zip
+Remove-Item -Recurse -Force azulJDK8.zip
+Remove-Item -Recurse -Force azulJDK11.zip
 
 Import-Module -Name ImageHelpers -Force
 
@@ -27,6 +40,9 @@ foreach ($pathSegment in $pathSegments)
     }
 }
 
+$java7Installs = Get-ChildItem -Path 'C:\Program Files\Java' -Filter 'jdk*7*' | Sort-Object -Property Name -Descending | Select-Object -First 1
+$latestJava7Install = $java7Installs.FullName;
+
 $java8Installs = Get-ChildItem -Path 'C:\Program Files\Java' -Filter 'jdk*8*' | Sort-Object -Property Name -Descending | Select-Object -First 1
 $latestJava8Install = $java8Installs.FullName;
 
@@ -39,8 +55,14 @@ $newPath = $latestJava8Install + '\bin;' + $newPath
 Set-MachinePath -NewPath $newPath
 
 setx JAVA_HOME $latestJava8Install /M
+setx JAVA_HOME_7_X64 $latestJava7Install /M
 setx JAVA_HOME_8_X64 $latestJava8Install /M
 setx JAVA_HOME_11_X64 $latestJava11Install /M
+
+#Install Java Tools
+choco install ant -y
+choco install maven -y
+choco install gradle -y
 
 #Move maven variables to Machine, they may not be in the environment for this script so we need to read them from the registry.
 $userSid = (Get-WmiObject win32_useraccount -Filter "name = '$env:USERNAME' AND domain = '$env:USERDOMAIN'").SID

--- a/images/win/scripts/Installers/Install-JavaTools.ps1
+++ b/images/win/scripts/Installers/Install-JavaTools.ps1
@@ -5,23 +5,19 @@
 ################################################################################
 
 ## Downloading azul jdks
-$azulJDK7Uri = 'https://repos.azul.com/azure-only/zulu/packages/zulu-7/7u191/zulu-7-azure-jdk_7.24.0.2-7.0.191-win_x64.zip'
 $azulJDK8Uri = 'https://repos.azul.com/azure-only/zulu/packages/zulu-8/8u181/zulu-8-azure-jdk_8.31.0.2-8.0.181-win_x64.zip'
 $azulJDK11Uri = 'https://repos.azul.com/azure-only/zulu/packages/zulu-11/11.0.1/zulu-11-azure-jdk_11.2.3-11.0.1-win_x64.zip'
 
 cd $env:TEMP
 
-Invoke-WebRequest -UseBasicParsing -Uri $azulJDK7Uri -OutFile azulJDK7.zip
 Invoke-WebRequest -UseBasicParsing -Uri $azulJDK8Uri -OutFile azulJDK8.zip
 Invoke-WebRequest -UseBasicParsing -Uri $azulJDK11Uri -OutFile azulJDK11.zip
 
 # Expand the zips
-Expand-Archive -Path azulJDK7.zip -DestinationPath "C:\Program Files\Java\" -Force
 Expand-Archive -Path azulJDK8.zip -DestinationPath "C:\Program Files\Java\" -Force
 Expand-Archive -Path azulJDK11.zip -DestinationPath "C:\Program Files\Java\" -Force
 
 # Deleting zip folders
-Remove-Item -Recurse -Force azulJDK7.zip
 Remove-Item -Recurse -Force azulJDK8.zip
 Remove-Item -Recurse -Force azulJDK11.zip
 
@@ -40,9 +36,6 @@ foreach ($pathSegment in $pathSegments)
     }
 }
 
-$java7Installs = Get-ChildItem -Path 'C:\Program Files\Java' -Filter 'jdk*7*' | Sort-Object -Property Name -Descending | Select-Object -First 1
-$latestJava7Install = $java7Installs.FullName;
-
 $java8Installs = Get-ChildItem -Path 'C:\Program Files\Java' -Filter 'jdk*8*' | Sort-Object -Property Name -Descending | Select-Object -First 1
 $latestJava8Install = $java8Installs.FullName;
 
@@ -55,7 +48,6 @@ $newPath = $latestJava8Install + '\bin;' + $newPath
 Set-MachinePath -NewPath $newPath
 
 setx JAVA_HOME $latestJava8Install /M
-setx JAVA_HOME_7_X64 $latestJava7Install /M
 setx JAVA_HOME_8_X64 $latestJava8Install /M
 setx JAVA_HOME_11_X64 $latestJava11Install /M
 

--- a/images/win/scripts/Installers/Validate-JavaTools.ps1
+++ b/images/win/scripts/Installers/Validate-JavaTools.ps1
@@ -18,14 +18,14 @@ else
 }
 
 
-if( $( $(& $env:comspec "/s /c java -version 2>&1") | Out-String) -match  'java version "(?<version>.*)".*' )
+if( $( $(& $env:comspec "/s /c java -version 2>&1") | Out-String) -match  '^(?<vendor>.+) version "(?<version>.+)".*' )
 {
    $javaVersion = $Matches.version
 }
 
 $env:Path = $env:JAVA_HOME_11_X64 + "\bin;" + $env:Path
 
-if( $( $(& $env:comspec "/s /c java -version 2>&1") | Out-String) -match  'java version "(?<version>.*)".*' )
+if( $( $(& $env:comspec "/s /c java -version 2>&1") | Out-String) -match  '^(?<vendor>.+) version "(?<version>.+)".*' )
 {
    $java11Version = $Matches.version
 }


### PR DESCRIPTION
Removing Oracle JDKs and OpenJDKs from the hosted build images and replacing them with Azul JDKs.

Verified both scripts on Azure VMs.