### PR TITLE
Hosted Preview macOS image software updates week 44

### DIFF
--- a/images/macos/macos-Readme.md
+++ b/images/macos/macos-Readme.md
@@ -11,25 +11,26 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 ### Language and Runtime
 
 - Java 1.7.0_80
-- Java 1.8.0_181
+- Java 1.8.0_192
 - Java 9.0.4
 - Java 10.0.2
+- Java 11.0.1
 - Node.js 6.14.4
 - Node.js 8.11.3
 - NVM 0.33.11
 - PowerShell 6.1.0
 - Python 2.7.10
 - Python 3.7.0
-- Ruby 2.5.1p57
-- .NET Core SDK 1.0.1, 1.0.4, 1.1.4, 1.1.5, 1.1.7, 1.1.8, 1.1.9, 2.0.0, 2.0.3, 2.1.100, 2.1.101, 2.1.102, 2.1.103, 2.1.104, 2.1.105, 2.1.2, 2.1.200, 2.1.201, 2.1.300, 2.1.301, 2.1.4, 2.1.400, 2.1.401 2.1.402
+- Ruby 2.5.3p105
+- .NET Core SDK 1.0.1, 1.0.4, 1.1.4, 1.1.5, 1.1.7, 1.1.8, 1.1.9, 1.1.10, 1.1.11, 2.0.0, 2.0.3, 2.1.100, 2.1.101, 2.1.102, 2.1.103, 2.1.104, 2.1.105, 2.1.2, 2.1.200, 2.1.201, 2.1.300, 2.1.301, 2.1.4, 2.1.400, 2.1.401 2.1.402
 - Go 1.11
 
 ### Package Management
 
 - Bundler 1.16.1
-- Carthage 0.30.1
+- Carthage 0.31.1
 - CocoaPods 1.5.3
-- Homebrew 1.7.6
+- Homebrew 1.8.0
 - NPM 3.10.10
 - Yarn 1.10.1
 - NuGet 4.7.0.5148
@@ -44,16 +45,16 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 ### Utilities
 
 - curl 7.54.0 (libcurl/7.54.0 LibreSSL/2.0.20 zlib/1.2.11 nghttp2/1.24.0)
-- Git 2.19.0
+- Git 2.19.1
 - Git LFS 2.5.2
 - GNU Wget 1.19.5
 - Subversion (SVN) 1.10.2
 
 ### Tools
 
-- fastlane 2.105.2
-- App Center CLI 1.1.2
-- Azure-CLI 2.0.46
+- fastlane 2.107.0
+- App Center CLI 1.1.5
+- Azure-CLI 2.0.49
 
 ### Pre-cached tools
 - Python 2.7.15 3.4.8 3.5.5 3.6.5 3.7.0
@@ -61,7 +62,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 ### Xcode
 | Version                | Build   | Path                          |
 |------------------------|---------|-------------------------------|
-| 10.1 beta 1            | 10O23u  | /Applications/Xcode_10.1.app  |
+| 10.1 beta 3            | 10O45e  | /Applications/Xcode_10.3.app  |
 | 10.0                   | 10A255  | /Applications/Xcode_10.app    |
 | 9.4.1                  | 9F2000  | /Applications/Xcode_9.4.1.app |
 | 9.4                    | 9F1027a | /Applications/Xcode_9.4.app   |
@@ -81,10 +82,10 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 ### Xcode Support Tools
 
-- Nomad CLI 2.7.6
+- Nomad CLI 2.7.7
 - Nomad CLI IPA 0.14.3
 - xcpretty 0.3.0
-- xctool 0.3.4
+- xctool 0.3.5
 
 ### Installed SDKs
 | SDK                       | SDK name    |


### PR DESCRIPTION
**Software updates:**

    Xcode Version: 10.1_beta_3 (10O45e)
    ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-darwin17]
    Git: git version 2.19.1
    Homebrew 1.8.0
    xctool 0.3.5
    Bundler 1.16.2
    Nomad CLI 2.7.7
    App Center CLI 1.1.5
    fastlane 2.107.0
    Carthage 0.31.1
    java 1.8 jdk: 1.8.0_192 (default)
    java 11 jdk: 11.0.1
    azure-cli (2.0.49)
    NET SDK 1.1.10, 1.1.11

Pre-cached packages: 10/22