### PR TITLE
Updated Xcode 10.1 path

### DIFF
--- a/images/macos/macos-Readme.md
+++ b/images/macos/macos-Readme.md
@@ -62,7 +62,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 ### Xcode
 | Version                | Build   | Path                          |
 |------------------------|---------|-------------------------------|
-| 10.1                   | 10B61   | /Applications/Xcode_10.3.app  |
+| 10.1                   | 10B61   | /Applications/Xcode_10.1.app  |
 | 10.0                   | 10A255  | /Applications/Xcode_10.app    |
 | 9.4.1                  | 9F2000  | /Applications/Xcode_9.4.1.app |
 | 9.4                    | 9F1027a | /Applications/Xcode_9.4.app   |


### PR DESCRIPTION
I have tried the previous path on AzureDevops but unfortunately `/Applications/Xcode_10.3.app` is not the correct path. 

When selecting Xcode version by following
```
sudo xcode-select -s /Applications/Xcode_10.3.app/Contents/Developer
```

AzureDevops throws:
```
xcode-select: error: invalid developer directory '/Applications/Xcode_10.3.app/Contents/Developer'
```

The proposed change is now tested and works:

```
2018-11-17T14:22:08.2464920Z sudo xcode-select -s /Applications/Xcode_10.1.app/Contents/Developer
2018-11-17T14:22:08.2526270Z [command]/bin/bash --noprofile --norc /Users/vsts/agent/2.141.1/work/_temp/a4ac7228-8ab2-4f76-9c59-718375b659a7.sh
```

Related Issue is created: #370 