### PR TITLE
Go: Update to the latest revision of Go 1.11 on Linux

### DIFF
--- a/images/linux/scripts/installers/go.sh
+++ b/images/linux/scripts/installers/go.sh
@@ -32,4 +32,4 @@ function InstallGo () {
 # Install Go versions
 InstallGo 1.9 1.9.7 false
 InstallGo 1.10 1.10.4 false
-InstallGo 1.11 1.11 true
+InstallGo 1.11 1.11.2 true


### PR DESCRIPTION
For linux images: changes go version from 1.11 to 1.11.2

Minor revisions 1.11.2 includes changes: 
https://golang.org/doc/devel/release.html#go1.11.minor
https://github.com/golang/go/issues?q=milestone%3AGo1.11.2

Which also includes changes for 1.11.1:
https://github.com/golang/go/issues?q=milestone%3AGo1.11.1