### PR TITLE
Update Android SDK Build Tools in Linux and Windows images to 28.0.3 …

### DIFF
--- a/images/linux/scripts/installers/android.sh
+++ b/images/linux/scripts/installers/android.sh
@@ -38,6 +38,7 @@ echo "y" | ${ANDROID_ROOT}/tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} \
     "platforms;android-17" \
     "platforms;android-15" \
     "platforms;android-10" \
+    "build-tools;28.0.3" \
     "build-tools;28.0.2" \
     "build-tools;28.0.0" \
     "build-tools;27.0.3" \
@@ -92,6 +93,7 @@ DocumentInstalledItem "Android SDK Platform 17"
 DocumentInstalledItem "Android SDK Platform 15"
 DocumentInstalledItem "Android SDK Platform 10"
 DocumentInstalledItem "Android SDK Patch Applier v4"
+DocumentInstalledItem "Android SDK Build-Tools 28.0.3"
 DocumentInstalledItem "Android SDK Build-Tools 28.0.2"
 DocumentInstalledItem "Android SDK Build-Tools 28.0.0"
 DocumentInstalledItem "Android SDK Build-Tools 27.0.3"

--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -60,6 +60,7 @@ Push-Location -Path $sdk.FullName
     "platforms;android-17" `
     "platforms;android-15" `
     "platforms;android-10" `
+    "build-tools;28.0.3" `
     "build-tools;28.0.0" `
     "build-tools;27.0.3" `
     "build-tools;27.0.1" `


### PR DESCRIPTION
…as required by Android Gradle Plugin 3.2.1