### PR TITLE
Update docs with deprecated XCodes

### DIFF
--- a/images/macos/macos-Readme.md
+++ b/images/macos/macos-Readme.md
@@ -194,18 +194,21 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | iOS 11.3 | 15E217 |
 | iOS 11.4 | 15F79 |
 | iOS 12.0 | 16A5288q |
+| iOS 12.1 | 16B91 |
 | tvOS 10.2 | 14W260 |
 | tvOS 11.1 | 15J580 |
 | tvOS 11.2 | 15K104 |
 | tvOS 11.3 | 15L211 |
 | tvOS 11.4 | 15L576 |
 | tvOS 12.0 | 16J5283n |
+| tvOS 12.1 | 16J602 |
 | watchOS 3.2 | 14V243 |
 | watchOS 4.0 | 15R372 |
 | watchOS 4.1 | 15R844 |
 | watchOS 4.2 | 15S100 |
 | watchOS 4.3 | 15T212 |
 | watchOS 5.0 | 16R5283q |
+| watchOS 5.1 | 16R591 |
 
 #### Devices
 
@@ -249,7 +252,21 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - iPad Air 2
 - iPad Pro
 
-#### iOS 10.0, 10.1, 10.2, 10.3
+#### iOS 10.0
+
+- iPhone 5
+- iPhone 5s
+- iPhone 6
+- iPhone 6 Plus
+- iPhone 6s
+- iPhone 6s Plus
+- iPhone SE
+- iPad Air
+- iPad Air 2
+- iPad Pro (9.7 inch)
+- iPad Pro (12.9 inch)
+
+#### iOS 10.1, 10.2, 10.3
 
 - iPhone 5
 - iPhone 5s
@@ -265,7 +282,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - iPad Pro (9.7 inch)
 - iPad Pro (12.9 inch)
 
-#### iOS 11, 11.1, 11.2, 11.3, 11.4
+#### iOS 11.0, 11.1, 11.2, 11.3, 11.4
 
 - iPhone 5s
 - iPhone 6
@@ -286,7 +303,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - iPad Pro (12.9-inch) (2nd generation)
 - iPad Pro (10.5-inch)
 
-#### iOS 12
+#### iOS 12.0
 
 - iPhone 5s
 - iPhone 6
@@ -299,6 +316,9 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - iPhone 8
 - iPhone 8 Plus
 - iPhone X
+- iPhone XR
+- iPhone XS
+- iPhone XS Max
 - iPad Air
 - iPad Air 2
 - iPad (5th generation)
@@ -309,24 +329,52 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - iPad Pro (12.9-inch) (2nd generation)
 - iPad (6th generation)
 
-#### tvOS 10, 10.1, 10.2
+#### iOS 12.1
+
+- iPhone 5s
+- iPhone 6
+- iPhone 6 Plus
+- iPhone 6s
+- iPhone 6s Plus
+- iPhone 7
+- iPhone 7 Plus
+- iPhone SE
+- iPhone 8
+- iPhone 8 Plus
+- iPhone X
+- iPhone X
+- iPhone XS
+- iPhone XS Max
+- iPhone XR
+- iPad Air
+- iPad Air 2
+- iPad (5th generation)
+- iPad Pro (9.7-inch)
+- iPad Pro (12.9-inch)
+- iPad Pro (12.9-inch) (2nd generation)
+- iPad Pro (10.5-inch)
+- iPad (6th generation)
+- iPad Pro (11-inch)
+- iPad Pro (12.9-inch) (3rd generation)
+
+#### tvOS 10.2
 
 - Apple TV 1080p
 
-#### tvOS 11, 11.1, 11.2, 11.3, 11.4, 12
+#### tvOS 11.0, 11.1, 11.2, 11.3, 11.4, 12, 12.1
 
 - Apple TV
 - Apple TV 4K
 - Apple TV 4K (at 1080p)
 
-#### watchOS 3.0, 3.1, 3.2
+#### watchOS 3.2
 
 - Apple Watch - 38mm
 - Apple Watch - 42mm
 - Apple Watch Series 2 - 38mm
 - Apple Watch Series 2 - 42mm
 
-#### watchOS 4.0, 4.1, 4.2, 4.3, 5.0
+#### watchOS 4.0, 4.1, 4.2, 4.3
 
 - Apple Watch - 38mm
 - Apple Watch - 42mm
@@ -334,6 +382,15 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - Apple Watch Series 2 - 42mm
 - Apple Watch Series 3 - 38mm
 - Apple Watch Series 3 - 42mm
+
+#### watchOS 5.0, 5.1
+
+- Apple Watch Series 2 - 38mm
+- Apple Watch Series 2 - 42mm
+- Apple Watch Series 3 - 38mm
+- Apple Watch Series 3 - 42mm
+- Apple Watch Series 4 - 40mm
+- Apple Watch Series 4 - 44mm
 
 ### Device Pairs
 

--- a/images/macos/macos-Readme.md
+++ b/images/macos/macos-Readme.md
@@ -73,12 +73,6 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | 9.0.1                  | 9A1004  | /Applications/Xcode_9.0.1.app |
 | 9.0                    | 9A235   | /Applications/Xcode_9.app     |
 | 8.3.3                  | 8E3004b | /Applications/Xcode_8.3.3.app |
-| 8.3.2                  | 8E2002  | /Applications/Xcode_8.3.2.app |
-| 8.3.1                  | 8E1000a | /Applications/Xcode_8.3.1.app |
-| 8.2.1                  | 8C1002  | /Applications/Xcode_8.2.1.app |
-| 8.2                    | 8C38    | /Applications/Xcode_8.2.app   |
-| 8.1                    | 8B62    | /Applications/Xcode_8.1.app   |
-| 8.0                    | 8A218a  | /Applications/Xcode_8.app     |
 
 ### Xcode Support Tools
 

--- a/images/macos/macos-Readme.md
+++ b/images/macos/macos-Readme.md
@@ -87,9 +87,6 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | macOS 10.12               | macosx10.12 |
 | macOS 10.13               | macosx10.13 |
 | macOS 10.14               | macosx10.14 |
-| iOS 10.0                  | iphoneos10.0 |
-| iOS 10.1                  | iphoneos10.1 |
-| iOS 10.2                  | iphoneos10.2 |
 | iOS 10.3                  | iphoneos10.3 |
 | iOS 11.0                  | iphoneos11.0 |
 | iOS 11.1                  | iphoneos11.1 |
@@ -98,9 +95,6 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | iOS 11.4                  | iphoneos11.4 |
 | iOS 12.0                  | iphoneos12.0 |
 | iOS 12.1                  | iphoneos12.1 |
-| iOS Simulator 10.0        | iphonesimulator10.0 |
-| iOS Simulator 10.1        | iphonesimulator10.1 |
-| iOS Simulator 10.2        | iphonesimulator10.2 |
 | iOS Simulator 10.3        | iphonesimulator10.3 |
 | iOS Simulator 11.0        | iphonesimulator11.0 |
 | iOS Simulator 11.1        | iphonesimulator11.1 |
@@ -109,8 +103,6 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | iOS Simulator 11.4        | iphonesimulator11.4 |
 | iOS Simulator 12.0        | iphonesimulator12.0 |
 | iOS Simulator 12.1        | iphonesimulator12.1 |
-| tvOS 10.0                 | appletvos10.0 |
-| tvOS 10.1                 | appletvos10.1 |
 | tvOS 10.2                 | appletvos10.2 |
 | tvOS 11.0                 | appletvos11.0 |
 | tvOS 11.1                 | appletvos11.1 |
@@ -119,8 +111,6 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | tvOS 11.4                 | appletvos11.4 |
 | tvOS 12.0                 | appletvos12.0 |
 | tvOS 12.1                 | appletvos12.1 |
-| tvOS Simulator 10.0       | appletvsimulator10.0 |
-| tvOS Simulator 10.1       | appletvsimulator10.1 |
 | tvOS Simulator 10.2       | appletvsimulator10.2 |
 | tvOS Simulator 11.0       | appletvsimulator11.0 |
 | tvOS Simulator 11.1       | appletvsimulator11.1 |
@@ -129,8 +119,6 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | tvOS Simulator 11.4       | appletvsimulator11.4 |
 | tvOS Simulator 12.0       | appletvsimulator12.0 |
 | tvOS Simulator 12.1       | appletvsimulator12.1 |
-| watchOS 3.0               | watchos3.0 |
-| watchOS 3.1               | watchos3.1 |
 | watchOS 3.2               | watchos3.2 |
 | watchOS 4.0               | watchos4.0 |
 | watchOS 4.1               | watchos4.1 |
@@ -138,8 +126,6 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | watchOS 4.3               | watchos4.3 |
 | watchOS 5.0               | watchos5.0 |
 | watchOS 5.1               | watchos5.1 |
-| watchOS Simulator 3.0     | watchsimulator3.0 |
-| watchOS Simulator 3.1     | watchsimulator3.1 |
 | watchOS Simulator 3.2     | watchsimulator3.2 |
 | watchOS Simulator 4.0     | watchsimulator4.0 |
 | watchOS Simulator 4.1     | watchsimulator4.1 |
@@ -179,7 +165,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - iPad Pro (12.9-inch)
 - iPad Pro (12.9-inch) (2nd generation)
 - iPad (6th generation)
-- Apple TV
+- Apple TV 1080p
 - Apple TV 4K
 - Apple TV 4K (at 1080p)
 - Apple Watch - 38mm
@@ -208,16 +194,12 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | iOS 11.3 | 15E217 |
 | iOS 11.4 | 15F79 |
 | iOS 12.0 | 16A5288q |
-| tvOS 10.0 | 14T328 |
-| tvOS 10.1 | 14U591 |
 | tvOS 10.2 | 14W260 |
 | tvOS 11.1 | 15J580 |
 | tvOS 11.2 | 15K104 |
 | tvOS 11.3 | 15L211 |
 | tvOS 11.4 | 15L576 |
 | tvOS 12.0 | 16J5283n |
-| watchOS 3.0 | 14S326 |
-| watchOS 3.1 | 14S471a |
 | watchOS 3.2 | 14V243 |
 | watchOS 4.0 | 15R372 |
 | watchOS 4.1 | 15R844 |
@@ -233,7 +215,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - iPhone 5
 - iPhone 5s
 - iPhone 6
-- iPhone 6
+- iPhone 6 Plus
 - iPad 2
 - iPad Retina
 - iPad Air


### PR DESCRIPTION
We have removed deprecated XCode versions and related simulators from the documentation.
Also we have fixed incorrect names of existed devices.