### PR TITLE
Improve Windows Defender scan performance

### DIFF
--- a/images/win/scripts/Installers/Vs2017/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Vs2017/Initialize-VM.ps1
@@ -47,7 +47,7 @@ else {
     Write-Host "Windows Update key does not exist"
 }
 
-# Insatll Windows .NET Features
+# Install Windows .NET Features
 Install-WindowsFeature -Name NET-Framework-Features -IncludeAllSubFeature
 Install-WindowsFeature -Name NET-Framework-45-Features -IncludeAllSubFeature
 Install-WindowsFeature -Name BITS -IncludeAllSubFeature

--- a/images/win/scripts/Installers/Vs2017/Run-Antivirus.ps1
+++ b/images/win/scripts/Installers/Vs2017/Run-Antivirus.ps1
@@ -8,7 +8,7 @@
 Write-Host "Run antivirus"
 Push-Location "C:\Program Files\Windows Defender"
 
-# Tell it to use 100% of the CPU during the scan
+# Tell Defender to use 100% of the CPU during the scan
 Set-MpPreference -ScanAvgCPULoadFactor 100
 
 # Full Scan
@@ -17,4 +17,4 @@ Pop-Location
 
 Write-Host "Set antivirus parmeters"
 Set-MpPreference -ScanAvgCPULoadFactor 5 `
-                 -ExclusionPath "D:\", "C:\"
+    -ExclusionPath "D:\", "C:\"

--- a/images/win/scripts/Installers/Vs2017/Run-Antivirus.ps1
+++ b/images/win/scripts/Installers/Vs2017/Run-Antivirus.ps1
@@ -7,6 +7,10 @@
 
 Write-Host "Run antivirus"
 Push-Location "C:\Program Files\Windows Defender"
+
+# Tell it to use 100% of the CPU during the scan
+Set-MpPreference -ScanAvgCPULoadFactor 100
+
 # Full Scan
 .\MpCmdRun.exe -Scan -ScanType 2
 Pop-Location

--- a/images/win/scripts/Installers/Vs2017/Run-Antivirus.ps1
+++ b/images/win/scripts/Installers/Vs2017/Run-Antivirus.ps1
@@ -17,4 +17,4 @@ Pop-Location
 
 Write-Host "Set antivirus parmeters"
 Set-MpPreference -ScanAvgCPULoadFactor 5 `
-    -ExclusionPath "D:\", "C:\"
+                 -ExclusionPath "D:\", "C:\"


### PR DESCRIPTION
This changes a setting that will allow Windows Defender to access 100% of the CPU during the full scan.  In my testing, it's reduced the time it takes to create an image by a little over 50% when using Premium_LRS storage.

Also fixes a super tiny comment typo.