### PR TITLE
Fixed DACFx validation bug

### DIFF
--- a/images/win/scripts/Installers/Validate-DACFx.ps1
+++ b/images/win/scripts/Installers/Validate-DACFx.ps1
@@ -4,7 +4,7 @@
 ##  Desc:  Validate SQL Server® Data-Tier Application Framework (DACFx) for Windows
 ####################################################################################
 
-$env:PATH = $env:Path + ';C:\Program Files\Microsoft SQL Server\120\DAC\bin;C:\Program Files\Microsoft SQL Server\130\DAC\bin;C:\Program Files\Microsoft SQL Server\140\DAC\bin'
+$env:PATH = $env:Path + ';C:\Program Files\Microsoft SQL Server\120\DAC\bin;C:\Program Files\Microsoft SQL Server\130\DAC\bin;C:\Program Files\Microsoft SQL Server\140\DAC\bin;C:\Program Files\Microsoft SQL Server\150\DAC\bin'
 
 if(Get-Command -Name 'SqlPackage')
 {


### PR DESCRIPTION
The latest version of DACFx causes the current VS 2017 build script to fail, due to it being installed in a different directory.  This fixes the validation script to include the additional directory, thus allowing the version check to successfully complete.