### PR TITLE
Remove old Android SDKs 10, 15, 17

### DIFF
--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -57,9 +57,6 @@ Push-Location -Path $sdk.FullName
     "platforms;android-22" `
     "platforms;android-21" `
     "platforms;android-19" `
-    "platforms;android-17" `
-    "platforms;android-15" `
-    "platforms;android-10" `
     "build-tools;28.0.3" `
     "build-tools;28.0.2" `
     "build-tools;28.0.1" `
@@ -87,7 +84,6 @@ Push-Location -Path $sdk.FullName
     "build-tools;21.1.2" `
     "build-tools;20.0.0" `
     "build-tools;19.1.0" `
-    "build-tools;17.0.0" `
     "extras;android;m2repository" `
     "extras;google;m2repository" `
     "extras;google;google_play_services" `


### PR DESCRIPTION
This PR removes the oldest 3 Android SDK versions which are also [no longer supported by Google](https://en.wikipedia.org/wiki/Android_version_history):
- **10** released December 6, 2010
- **15** released October 18, 2011
- **17** released July 9, 2012

AppVeyor doesn't provide these either.