### PR TITLE
Hosted Preview macOS image software updates week 2

### DIFF
--- a/images/macos/macos-Readme.md
+++ b/images/macos/macos-Readme.md
@@ -15,24 +15,24 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - Java 9.0.4
 - Java 10.0.2
 - Java 11.0.1
-- Node.js 6.14.4
+- Node.js 6.16.0
 - Node.js 8.11.3
 - NVM 0.33.11
 - PowerShell 6.1.1
 - Python 2.7.10
-- Python 3.7.0
-- Ruby 2.3.7p456
-- .NET Core SDK 1.0.1, 1.0.4, 1.1.4, 1.1.5, 1.1.7, 1.1.8, 1.1.9, 1.1.10, 1.1.11, 2.0.0, 2.0.3, 2.1.100, 2.1.101, 2.1.102, 2.1.103, 2.1.104, 2.1.105, 2.1.2, 2.1.200, 2.1.201, 2.1.300, 2.1.301, 2.1.4, 2.1.400, 2.1.401 2.1.402 2.1.502 2.2.101
+- Python 3.7.2
+- Ruby 2.6.0p0
+- .NET Core SDK 1.0.1, 1.0.4, 1.1.4, 1.1.5, 1.1.7, 1.1.8, 1.1.9, 1.1.10, 1.1.11, 2.0.0, 2.0.3, 2.1.100, 2.1.101, 2.1.102, 2.1.103, 2.1.104, 2.1.105, 2.1.503, 2.1.2, 2.1.200, 2.1.201, 2.1.300, 2.1.301, 2.1.4, 2.1.400, 2.1.401 2.1.402 2.1.502 2.2.101, 2.2.102
 - Go 1.11.4
 
 ### Package Management
 
-- Bundler 1.17.2
+- Bundler 2.0.1
 - Carthage 0.31.2
 - CocoaPods 1.5.3
-- Homebrew 1.8.6
+- Homebrew 1.9.0
 - NPM 3.10.10
-- Yarn 1.12.1
+- Yarn 1.13.0
 - NuGet 4.7.0.5148
 - pip 18.0
 - Miniconda 4.5.11
@@ -40,21 +40,21 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 ### Project Management
 
 - Apache Maven 3.6.0
-- Gradle 5.0
+- Gradle 5.1
 
 ### Utilities
 
-- curl 7.54.0 (libcurl/7.54.0 LibreSSL/2.0.20 zlib/1.2.11 nghttp2/1.24.0)
+- curl 7.63.0 (libcurl/7.54.0 LibreSSL/2.0.20 zlib/1.2.11 nghttp2/1.24.0)
 - Git 2.20.1
 - Git LFS 2.6.1
-- GNU Wget 1.20
-- Subversion (SVN) 1.10.2
+- GNU Wget 1.20.1
+- Subversion (SVN) 1.11.0
 
 ### Tools
 
-- fastlane 2.111.0
+- fastlane 2.113.0
 - App Center CLI 1.1.9
-- Azure-CLI 2.0.51
+- Azure-CLI 2.0.54
 
 ### Pre-cached tools
 - Python 2.7.15 3.4.8 3.5.5 3.6.5 3.7.0
@@ -76,7 +76,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 ### Xcode Support Tools
 
-- Nomad CLI 2.7.7
+- Nomad CLI 3.0.1
 - Nomad CLI IPA 0.14.3
 - xcpretty 0.3.0
 - xctool 0.3.5


### PR DESCRIPTION

    Ruby 2.6.0p0 (2018-12-25 revision 66547)
    Python 3.7.2
    Node.js v6.16.0
    Curl 7.63.0 (x86_64-apple-darwin17.7.0)
    GNU Wget 1.20.1
    Bundler version 2.0.1
    Nomad CLI 3.0.1
    Fastlane 2.113.0
    Gradle 5.1
    Homebrew 1.9.0
    Yarn 1.13.0
    .NET SDK 2.1.503, 2.2.102
    Azure-cli (2.0.54)
    Subversion (SVN) 1.11.0
    OpenSSL 1.0.2q 20 Nov 2018
    Android Emulator 28.0.22
    Visual Studio for Mac: 7.7.2.21
    Xamarin.Android SDK Version: 9.1.4-2
