### PR TITLE
Removed "RequiredVersion" attribute from the Install-Docker command so as to download the stable version for Docker

### DIFF
--- a/images/win/scripts/Installers/Vs2017/Install-Docker.ps1
+++ b/images/win/scripts/Installers/Vs2017/Install-Docker.ps1
@@ -11,7 +11,7 @@ Write-Host "Install-Module DockerProvider"
 Install-Module DockerMsftProvider -Force
 
 Write-Host "Install-Package Docker"
-Install-Package -Name docker -ProviderName DockerMsftProvider -RequiredVersion 18.03 -Force
+Install-Package -Name docker -ProviderName DockerMsftProvider -Force
 Start-Service docker
 
 choco install docker-compose -y


### PR DESCRIPTION
Currently, we download Docker version 18.03 for windows. This change is to make sure that the stable version for Docker gets installed for VS2017 agent. By default, if the "RequiredVersion" attribute is not specified, the Install-Package command downloads the stable version

![image](https://user-images.githubusercontent.com/8982085/51312326-00e2c900-1a71-11e9-9289-ba05d2876058.png)
