### PR TITLE
Improve git and git-lfs install validation and Markdown output

### DIFF
--- a/images/linux/scripts/installers/git.sh
+++ b/images/linux/scripts/installers/git.sh
@@ -19,12 +19,20 @@ curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.s
 apt-get install -y --no-install-recommends git-lfs
 
 # Run tests to determine that the software installed as expected
-echo "Testing to make sure that script performed as expected, and basic scenarios work"
+echo "Testing git installation"
 if ! command -v git; then
     echo "git was not installed"
     exit 1
 fi
+echo "Testing git-lfs installation"
+if ! command -v git-lfs; then
+    echo "git-lfs was not installed"
+    exit 1
+fi
 
 # Document what was added to the image
-echo "Lastly, documenting what we added to the metadata file"
-DocumentInstalledItem "Git ($(git --version))"
+echo "Lastly, document the installed versions"
+# git version 2.20.1
+DocumentInstalledItem "Git ($(git --version 2>&1 | cut -d ' ' -f 3))"
+# git-lfs/2.6.1 (GitHub; linux amd64; go 1.11.1)
+DocumentInstalledItem "Git Large File Storage (LFS) ($(git-lfs --version 2>&1 | cut -d ' ' -f 1 | cut -d '/' -f 2))"

--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -10,8 +10,8 @@ source $HELPER_SCRIPTS/document.sh
 
 DEFAULT_JDK_VERSION=8
 
-#Install Azul jdks
-#Documentation for Azul JDK installation can be found here: https://www.azul.com/downloads/azure-only/zulu/
+# Install the Azul Systems Zulu JDKs
+# See https://www.azul.com/downloads/azure-only/zulu/
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9
 apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main"
 apt-get -q update

--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -6,6 +6,8 @@
 
 Import-Module -Name ImageHelpers
 
+# Install the latest version of Git which is bundled with Git LFS.
+# See https://chocolatey.org/packages/git
 choco install git -y --package-parameters= "/GitAndUnixToolsOnPath /WindowsTerminal /NoShellIntegration"
 
 Add-MachinePathItem "C:\Program Files\Git\mingw64\bin"

--- a/images/win/scripts/Installers/Install-JavaTools.ps1
+++ b/images/win/scripts/Installers/Install-JavaTools.ps1
@@ -4,7 +4,8 @@
 ##  Desc:  Install various JDKs and java tools
 ################################################################################
 
-## Downloading azul jdks
+# Download the Azul Systems Zulu JDKs
+# See https://www.azul.com/downloads/azure-only/zulu/
 $azulJDK8Uri = 'https://repos.azul.com/azure-only/zulu/packages/zulu-8/8u192/zulu-8-azure-jdk_8.33.0.1-8.0.192-win_x64.zip'
 $azulJDK11Uri = 'https://repos.azul.com/azure-only/zulu/packages/zulu-11/11.0.1/zulu-11-azure-jdk_11.2.3-11.0.1-win_x64.zip'
 

--- a/images/win/scripts/Installers/Validate-Git.ps1
+++ b/images/win/scripts/Installers/Validate-Git.ps1
@@ -38,7 +38,7 @@ _Environment:_
 Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description
 
 # Adding description of the software to Markdown
-$SoftwareName = "Git LFS"
+$SoftwareName = "Git Large File Storage (LFS)"
 
 $Description = @"
 _Version:_ $gitLfsVersion<br/>


### PR DESCRIPTION
This PR improves git and git-lfs install validation and Markdown output.  The Ubuntu image Markdown now looks like this:
- #### Git (2.20.1)
- #### Git Large File Storage (LFS) (2.6.1)

This PR is prompted by #392 and #393.