### PR TITLE
Add Rust to Linux and Windows

### DIFF
--- a/images/linux/scripts/installers/rust.sh
+++ b/images/linux/scripts/installers/rust.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+################################################################################
+##  File:  rust.sh
+##  Team:  CI-Platform
+##  Desc:  Installs Rust and its common tools
+################################################################################
+
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/document.sh
+source $HELPER_SCRIPTS/apt.sh
+
+# Install the latest 'stable' toolchain of Rust
+# See https://rustup.rs/# and https://github.com/rust-lang/rustup.rs
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+# Add Rust to the path of this shell instance
+source $HOME/.cargo/env
+
+# Install common tools
+rustup component add rustfmt
+rustup component add clippy
+cargo install bindgen
+cargo install cbindgen
+
+# Test that the software installed as expected
+echo "Test installation of the Rust toochain"
+for cmd in bindgen cargo cargo-clippy cargo-fmt cbindgen rustc rustdoc rustfmt rustup; do
+    if ! command -v $cmd --version; then
+        echo "$cmd was not installed or is not found on the path"
+        exit 1
+    fi
+done
+
+# Document what was added to the image
+echo "Lastly, document what was added to the metadata file"
+DocumentInstalledItem "Rust ($(rustc --version 2>&1 | cut -d ' ' -f 2))"
+DocumentInstalledItem "bindgen ($(bindgen --version 2>&1 | cut -d ' ' -f 2))"
+DocumentInstalledItem "cargo ($(cargo --version 2>&1 | cut -d ' ' -f 2))"
+DocumentInstalledItem "cbindgen ($(cbindgen --version 2>&1 | cut -d ' ' -f 2))"
+DocumentInstalledItem "clippy ($(cargo-clippy --version 2>&1 | cut -d ' ' -f 2))"
+DocumentInstalledItem "rustdoc ($(rustdoc --version 2>&1 | cut -d ' ' -f 2))"
+DocumentInstalledItem "rustfmt ($(rustfmt --version 2>&1 | cut -d ' ' -f 2))"
+DocumentInstalledItem "rustup ($(rustup --version 2>&1 | cut -d ' ' -f 2))"

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -123,6 +123,7 @@
                 "{{template_dir}}/scripts/installers/powershellcore.sh",
                 "{{template_dir}}/scripts/installers/python.sh",
                 "{{template_dir}}/scripts/installers/ruby.sh",
+                "{{template_dir}}/scripts/installers/rust.sh",
                 "{{template_dir}}/scripts/installers/scala.sh",
                 "{{template_dir}}/scripts/installers/sphinx.sh",
                 "{{template_dir}}/scripts/installers/subversion.sh",

--- a/images/win/scripts/Installers/Install-Rust.ps1
+++ b/images/win/scripts/Installers/Install-Rust.ps1
@@ -1,0 +1,29 @@
+################################################################################
+##  File:  Install-Rust.ps1
+##  Team:  CI-Platform
+##  Desc:  Install Rust for Windows
+################################################################################
+
+Import-Module -Name ImageHelpers
+
+# Download the latest rustup-init.exe for Windows x64
+# See https://rustup.rs/#
+Invoke-WebRequest -UseBasicParsing -Uri "https://win.rustup.rs/x86_64" -OutFile rustup-init.exe
+
+# Install Rust by running rustup-init.exe (disabling the confirmation prompt with -y)
+.\rustup-init.exe -y
+
+# Delete rustup-init.exe when it's no longer needed
+rm .\rustup-init.exe
+
+# Add Rust binaries to the path
+Add-MachinePathItem "$env:userprofile\.cargo\bin"
+$env:Path = Get-MachinePath
+
+# Install common tools
+rustup component add rustfmt
+rustup component add clippy
+cargo install bindgen
+cargo install cbindgen
+
+exit 0

--- a/images/win/scripts/Installers/Validate-Rust.ps1
+++ b/images/win/scripts/Installers/Validate-Rust.ps1
@@ -1,0 +1,34 @@
+################################################################################
+##  File:  Validate-Rust.ps1
+##  Team:  CI-X
+##  Desc:  Verify that Rust is on the path and output version information.
+################################################################################
+
+$RustPath = "$env:userprofile\.cargo\bin"
+$env:Path = $RustPath + ";" + $env:Path
+$RustcVersion = $(rustc --version)
+
+if(Get-Command -Name 'rustc')
+{
+    Write-Host "$RustcVersion is on the path"
+}
+else
+{
+     Write-Host "rustc is not on the path"
+    exit 1
+}
+
+$RustcVersion -Match "\d+\.\d+\.\d+" | out-null
+$Version = $Matches[0]
+
+# Adding description of the software to Markdown
+$SoftwareName = "Rust (64-bit)"
+
+$Description = @"
+#### $Version
+_Location:_ $RustPath
+_Environment:_
+* PATH: contains the location of rustc.exe
+"@
+
+Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -281,6 +281,12 @@
         {
             "type": "powershell",
             "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-Rust.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-Svn.ps1"
             ]
         },
@@ -514,6 +520,12 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-Ruby.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-Rust.ps1"
             ]
         },
         {


### PR DESCRIPTION
This addresses issue #495.
Canary tests are created in the Linux and VS2017 folders.