### PR TITLE
Added dotnet tool global path to VS2017 and ubuntu image global path variables

### DIFF
--- a/images/linux/scripts/installers/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/dotnetcore-sdk.sh
@@ -86,5 +86,6 @@ done
 # NuGetFallbackFolder at /usr/share/dotnet/sdk/NuGetFallbackFolder is warmed up by smoke test
 # Additional FTE will just copy to ~/.dotnet/NuGet which provides no benefit on a fungible machine
 echo "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" | tee -a /etc/environment
+echo "PATH=\"/home/vsts/.dotnet/tools:$PATH\"" | tee -a /etc/environment
 
 dotnet --info

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -51,3 +51,4 @@ $dotnetReleases | ForEach-Object {
 }
 
 Add-MachinePathItem "C:\Program Files\dotnet"
+Add-MachinePathItem "C:\Users\VssAdmisnitrator\.dotnet\tools"

--- a/images/win/scripts/Installers/Validate-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Validate-DotnetSDK.ps1
@@ -15,7 +15,7 @@ else
 }
 
 $CurrentPath = Get-MachinePath
-if (!($CurrentPath -Match "C:\Users\VssAdmisnitrator\.dotnet\tools"))
+if (!($CurrentPath -Like "*C:\Users\VssAdmisnitrator\.dotnet\tools*"))
 {
     Write-Host ".Net Core global tool path (C:\Users\VssAdmisnitrator\.dotnet\tools) is added to system path envrionment variable."
 }

--- a/images/win/scripts/Installers/Validate-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Validate-DotnetSDK.ps1
@@ -15,7 +15,7 @@ else
 }
 
 $CurrentPath = Get-MachinePath
-if (!($CurrentPath -Like "*C:\Users\VssAdmisnitrator\.dotnet\tools*"))
+if ($CurrentPath -Like "*C:\Users\VssAdmisnitrator\.dotnet\tools*")
 {
     Write-Host ".Net Core global tool path (C:\Users\VssAdmisnitrator\.dotnet\tools) is added to system path envrionment variable."
 }
@@ -24,7 +24,6 @@ else
     Write-Host ".Net Core global tool path is not on system path"
     exit 1
 }
-
 
 # Adding description of the software to Markdown
 $SoftwareName = ".NET Core"

--- a/images/win/scripts/Installers/Validate-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Validate-DotnetSDK.ps1
@@ -10,7 +10,18 @@ if(Get-Command -Name 'dotnet')
 }
 else
 {
-     Write-Host "dotnet is not on path"
+    Write-Host "dotnet is not on path"
+    exit 1
+}
+
+$CurrentPath = Get-MachinePath
+if (!($CurrentPath -Match "C:\Users\VssAdmisnitrator\.dotnet\tools"))
+{
+    Write-Host ".Net Core global tool path (C:\Users\VssAdmisnitrator\.dotnet\tools) is added to system path envrionment variable."
+}
+else
+{
+    Write-Host ".Net Core global tool path is not on system path"
     exit 1
 }
 


### PR DESCRIPTION
This PR attends to the ongoing issue for adding support for .Net global tool path availability on Hosted 2017 and Ubuntu images : #145 