### PR TITLE
change installer to use PowerShell Team's installer

### DIFF
--- a/images/win/scripts/Installers/Install-PowershellCore.ps1
+++ b/images/win/scripts/Installers/Install-PowershellCore.ps1
@@ -4,4 +4,4 @@
 ##  Desc:  Install Powershel Core
 ################################################################################
 
-choco install powershell-core --version 6.1.1 -y
+Invoke-Expression "& { $(Invoke-RestMethod https://aka.ms/install-powershell.ps1) } -UseMSI -Quiet"


### PR DESCRIPTION
Based on community feedback, request to use a Microsoft authored way to install PSCore6.  This uses the installer script written and maintained by PowerShell Team.