### PR TITLE
Change size of disk in VS2019 image and remove harcoded passwords from remaining Windows images

### DIFF
--- a/images/win/WindowsContainer1803-Azure.json
+++ b/images/win/WindowsContainer1803-Azure.json
@@ -17,7 +17,7 @@
         "helper_script_folder": "C:\\Program Files\\WindowsPowerShell\\Modules\\",
         "commit_id": "LATEST",
         "install_user": "installer",
-        "install_password": "P@ssw0rd1"
+        "install_password": null
     },
     "builders": [
         {

--- a/images/win/vs2015-Server2012R2-Azure.json
+++ b/images/win/vs2015-Server2012R2-Azure.json
@@ -17,7 +17,7 @@
         "helper_script_folder": "C:\\Program Files\\WindowsPowerShell\\Modules\\",
         "commit_id": "LATEST",
         "install_user": "installer",
-        "install_password": "P@ssw0rd1"
+        "install_password": null
     },
     "builders": [
         {

--- a/images/win/vs2019-Server2019-Azure.json
+++ b/images/win/vs2019-Server2019-Azure.json
@@ -29,7 +29,7 @@
             "subscription_id": "{{user `subscription_id`}}",
             "object_id": "{{user `object_id`}}",
             "tenant_id": "{{user `tenant_id`}}",
-            "os_disk_size_gb": "256",
+            "os_disk_size_gb": "128",
             "location": "{{user `location`}}",
             "vm_size": "{{user `vm_size`}}",
             "resource_group_name": "{{user `resource_group`}}",


### PR DESCRIPTION
Change VS2019 image disk size to 128 GB from 256 GB.
Remove hardcoded installer password for Windows Container and VS2015 images. Password had previously been removed from VS2017 and VS2019 images.