### PR TITLE
Spec arch to node.js in Vs2017-Server2016 image

### DIFF
--- a/images/win/Vs2017-Server2016-Readme.md
+++ b/images/win/Vs2017-Server2016-Readme.md
@@ -382,6 +382,7 @@ _Environment:_
 ## Node.js
 
 _Version:_ 10.14.2<br/>
+_Architecture:_ x64<br/>
 _Environment:_
 * PATH: contains location of node.exe<br/>
 

--- a/images/win/Vs2017-Server2016-Readme.md
+++ b/images/win/Vs2017-Server2016-Readme.md
@@ -381,7 +381,7 @@ _Environment:_
 
 ## Node.js
 
-_Version:_ 10.14.2<br/>
+_Version:_ 10.15.0<br/>
 _Architecture:_ x64<br/>
 _Environment:_
 * PATH: contains location of node.exe<br/>

--- a/images/win/scripts/Installers/Validate-NodeLts.ps1
+++ b/images/win/scripts/Installers/Validate-NodeLts.ps1
@@ -33,6 +33,7 @@ else
 if( $(node --version) -match  'v(?<version>.*)' )
 {
    $nodeVersion = $Matches.version
+   $nodeArch = $(node -e "console.log(process.arch)")
 }
 
 $npmVersion = $(npm -version)
@@ -46,6 +47,7 @@ $YarnInfo = "Yarn $(yarn -version)"
 
 $Description = @"
 _Version:_ $nodeVersion<br/>
+_Architecture:_ $nodeArch<br/>
 _Environment:_
 * PATH: contains location of node.exe<br/>
 * $GulpInfo<br/>


### PR DESCRIPTION
Addresses #611 
Added node `arch`.
Updated node version to current one, see today's build: https://dev.azure.com/pablo-nunez/Runner/_build/results?buildId=304