### PR TITLE
Enable long path behavior on Windows images

### DIFF
--- a/images/win/scripts/Installers/Vs2017/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Vs2017/Initialize-VM.ps1
@@ -66,6 +66,9 @@ Write-Host "Setting local execution policy"
 Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope MachinePolicy  -ErrorAction Continue | Out-Null
 Get-ExecutionPolicy -List
 
+Write-Host "Enable long path behavior"
+# See https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file#maximum-path-length-limitation
+Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -Value 1
 
 Write-Host "Install chocolatey"
 $chocoExePath = 'C:\ProgramData\Chocolatey\bin'

--- a/images/win/scripts/Installers/Vs2019/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Vs2019/Initialize-VM.ps1
@@ -66,6 +66,9 @@ Write-Host "Setting local execution policy"
 Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope LocalMachine  -ErrorAction Continue | Out-Null
 Get-ExecutionPolicy -List
 
+Write-Host "Enable long path behavior"
+# See https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file#maximum-path-length-limitation
+Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -Value 1
 
 Write-Host "Install chocolatey"
 $chocoExePath = 'C:\ProgramData\Chocolatey\bin'

--- a/images/win/scripts/Installers/WindowsContainer1803/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/WindowsContainer1803/Initialize-VM.ps1
@@ -4,7 +4,6 @@
 ##  Desc:  VM initialization script, machine level configuration
 ################################################################################
 
-
 function Disable-UserAccessControl {
     Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" -Name "ConsentPromptBehaviorAdmin" -Value 00000000 -Force
     Write-Host "User Access Control (UAC) has been disabled."
@@ -17,7 +16,6 @@ Write-Host "Setup PowerShellGet"
 Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
 Install-Module -Name PowerShellGet -Force
 Set-PSRepository -InstallationPolicy Trusted -Name PSGallery
-
 
 Write-Host "Disable Antivirus"
 Set-MpPreference -DisableRealtimeMonitoring $true
@@ -47,6 +45,9 @@ Write-Host "Setting local execution policy"
 Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope MachinePolicy -ErrorAction Continue | Out-Null
 Get-ExecutionPolicy -List
 
+Write-Host "Enable long path behavior"
+# See https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file#maximum-path-length-limitation
+Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -Value 1
 
 Write-Host "Install chocolatey"
 $chocoExePath = 'C:\ProgramData\Chocolatey\bin'
@@ -76,8 +77,6 @@ Invoke-Expression ((new-object net.webclient).DownloadString('https://chocolatey
 # Turn off confirmation
 choco feature enable -n allowGlobalConfirmation
 
-
-
 # Expand disk size of OS drive
 
 New-Item -Path d:\ -Name cmds.txt -ItemType File -Force
@@ -92,21 +91,18 @@ Write-Host "Disk sizes after expansion"
 
 wmic logicaldisk get size,freespace,caption
 
-
-
 # Adding description of the software to Markdown
 
 $Content = @"
-# VSTS Windows Container(1803) image
+# Azure Pipelines Windows Container 1803 image
 
-The following software is installed on machines in the VSTS **Windows Container(1803)** pool.
+The following software is installed on machines in the Azure Pipelines **Windows Container 1803** pool.
 
 Components marked with **\*** have been upgraded since the previous version of the image.
 
 "@
 
 Add-ContentToMarkdown -Content $Content
-
 
 $SoftwareName = "Chocolatey"
 


### PR DESCRIPTION
This fixes #157.

- [x] Tested on Windows Server 2016
- [x] Created canary test builds for VS2017 and VS2019

[Canary build for VS2017](https://dev.azure.com/buildcanary/CanaryBuilds/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=1646)
[Canary build for VS2019](https://dev.azure.com/buildcanary/CanaryBuilds/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=1647)
