### PR TITLE
Hosted macOS week 8 updates

### DIFF
--- a/images/macos/macos-Readme.md
+++ b/images/macos/macos-Readme.md
@@ -19,10 +19,10 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - Node.js 8.11.3
 - NVM 0.33.11
 - PowerShell 6.1.2
-- Python 2.7.10
+- Python 2.7.15
 - Python 3.7.2
 - Ruby 2.6.1p33
-- .NET Core SDK 1.0.1, 1.0.4, 1.1.4, 1.1.5, 1.1.7, 1.1.8, 1.1.9, 1.1.10, 1.1.11, 2.0.0, 2.0.3, 2.1.100, 2.1.101, 2.1.102, 2.1.103, 2.1.104, 2.1.105, 2.1.503, 2.1.2, 2.1.200, 2.1.201, 2.1.300, 2.1.301, 2.1.4, 2.1.400, 2.1.401 2.1.402 2.1.502 2.2.101, 2.2.102, 2.2.103
+- .NET Core SDK 1.0.1, 1.0.4, 1.1.4, 1.1.5, 1.1.7, 1.1.8, 1.1.9, 1.1.10, 1.1.11, 1.1.12, 2.0.0, 2.0.3, 2.1.100, 2.1.101, 2.1.102, 2.1.103, 2.1.104, 2.1.105, 2.1.503, 2.1.2, 2.1.200, 2.1.201, 2.1.300, 2.1.301, 2.1.4, 2.1.400, 2.1.401 2.1.402 2.1.502, 2.1.504, 2.2.101, 2.2.102, 2.2.103, 2.2.104
 - Go 1.11.5
 
 ### Package Management
@@ -30,7 +30,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - Bundler 2.0.1
 - Carthage 0.32.0
 - CocoaPods 1.5.3
-- Homebrew 2.0.0
+- Homebrew 2.0.2
 - NPM 3.10.10
 - Yarn 1.13.0
 - NuGet 4.7.0.5148
@@ -40,21 +40,21 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 ### Project Management
 
 - Apache Maven 3.6.0
-- Gradle 5.2.0
+- Gradle 5.2.1
 
 ### Utilities
 
 - curl 7.63.0 (libcurl/7.54.0 LibreSSL/2.0.20 zlib/1.2.11 nghttp2/1.24.0)
 - Git 2.20.1
-- Git LFS 2.6.1
+- Git LFS 2.7.0
 - GNU Wget 1.20.1
 - Subversion (SVN) 1.11.1
 
 ### Tools
 
-- fastlane 2.115.0
+- fastlane 2.116.0
 - App Center CLI 1.1.11
-- Azure-CLI 2.0.57
+- Azure-CLI 2.0.58
 
 ### Pre-cached tools
 - Python 2.7.15 3.4.8 3.5.5 3.6.5 3.7.0
@@ -475,7 +475,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 |-----------------------|-------------------------------------------|
 | cmake                 | 3.6.4111459                               |
 | lldb                  | 2.3.3614996                               |
-| ndk-bundle            | 19.0.5232133                              |
+| ndk-bundle            | 18.1.5063045                              |
 | ProGuard              | 5.3.3                                     |
 | Android Emulator      | 28.0.23                                    |
 
@@ -501,7 +501,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 ### Visual Studio for Mac
 
-- 7.7.3.43
+- 7.7.4.1
 
 ### Mono
 


### PR DESCRIPTION
    Python 2.7.15
    Pip 19.0.2
    Git LFS: git-lfs/2.7.0 (GitHub; darwin amd64; go 1.11.5)
    Curl 7.64.0 libcurl/7.64.0 SecureTransport zlib/1.2.11
    Homebrew 2.0.2
    Fastlane 2.116.0
    Gradle 5.2.1
    .NET SDK 1.1.12, 2.1.504, 2.2.104
    Azure-cli 2.0.58
    Android NDK 18.1.5063045
    Visual Studio for Mac: 7.7.4.1

Pre-cache packages 02/17