### PR TITLE
C/C++: Add the latest version of Boost (Linux, Windows)

### DIFF
--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -161,7 +161,7 @@
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}",
-                "BOOST_VERSIONS=1.66.0,1.67.0,1.68.0,1.69.0",
+                "BOOST_VERSIONS=1.69.0",
                 "BOOST_DEFAULT=1.69.0"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -429,7 +429,7 @@
         {
             "type": "powershell",
             "environment_vars": [
-                "BOOST_VERSIONS=1.66.0,1.67.0,1.68.0,1.69.0",
+                "BOOST_VERSIONS=1.69.0",
                 "BOOST_DEFAULT=1.69.0"
             ],
             "scripts":[
@@ -543,7 +543,7 @@
         {
             "type": "powershell",
             "environment_vars": [
-                "BOOST_VERSIONS=1.66.0,1.67.0,1.68.0,1.69.0",
+                "BOOST_VERSIONS=1.69.0",
                 "BOOST_DEFAULT=1.69.0"
             ],
             "scripts":[

--- a/images/win/vs2019-Server2019-Azure.json
+++ b/images/win/vs2019-Server2019-Azure.json
@@ -403,7 +403,7 @@
         {
             "type": "powershell",
             "environment_vars": [
-                "BOOST_VERSIONS=1.66.0,1.67.0,1.68.0,1.69.0",
+                "BOOST_VERSIONS=1.69.0",
                 "BOOST_DEFAULT=1.69.0"
             ],
             "scripts":[
@@ -511,7 +511,7 @@
         {
             "type": "powershell",
             "environment_vars": [
-                "BOOST_VERSIONS=1.66.0,1.67.0,1.68.0,1.69.0",
+                "BOOST_VERSIONS=1.69.0",
                 "BOOST_DEFAULT=1.69.0"
             ],
             "scripts":[


### PR DESCRIPTION
This PR is related to the [C/C++: Add the latest 4 versions of Boost 1.66.0 - 1.69.0 (Linux, Windows)](https://github.com/Microsoft/azure-pipelines-image-generation/pull/732)

We should revert Boost 1.66.0, 1.67.0, 1.68.0 for now.
So only Boost 1.69.0 will be available on the images.