### PR TITLE
VS2019 RC is out, change Preview to Enterprise

### DIFF
--- a/images/win/scripts/Installers/Vs2019/Install-WDK.ps1
+++ b/images/win/scripts/Installers/Vs2019/Install-WDK.ps1
@@ -34,7 +34,7 @@ if ($wdkExitCode -ne 0)
 # Write-Host "Installing WDK.vsix"
 <# ISSUE - VSIX installer failing on VS2019
  $process = Start-Process `
-    -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\Common7\IDE\VSIXInstaller.exe" `
+    -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\VSIXInstaller.exe" `
     -ArgumentList ("/quiet", '"C:\Program Files (x86)\Windows Kits\10\Vsix\WDK.vsix"') `
     -Wait `
     -PassThru

--- a/images/win/scripts/Installers/Vs2019/Install-Wix.ps1
+++ b/images/win/scripts/Installers/Vs2019/Install-Wix.ps1
@@ -11,7 +11,7 @@ function Install-VsixExtension
         [String]$Name
     )
 
-    $ReleaseInPath = 'Preview'
+    $ReleaseInPath = 'Enterprise'
     $exitCode = -1
 
     try


### PR DESCRIPTION
Since VS2019 RC is out, we need to change "Previews" -> "Enterprise".