### PR TITLE
Update Vs2017-Server2016-Readme.md

### DIFF
--- a/images/win/Vs2017-Server2016-Readme.md
+++ b/images/win/Vs2017-Server2016-Readme.md
@@ -4,6 +4,7 @@ The following software is installed on machines in the Azure Pipelines **Hosted 
 
 Components marked with **\*** have been upgraded since the previous version of the image.
 
+
 ## Chocolatey
 
 _Version:_ 0.10.11<br/>
@@ -12,28 +13,33 @@ _Environment:_
 
 ## Docker
 
-_Version:_ 18.03.1-ee-3<br/>
+_Version:_ 18.09.1<br/>
 _Environment:_
 * PATH: contains location of docker.exe
 
 ## Docker-compose
 
-_Version:_ 1.22.0<br/>
+_Version:_ 1.23.2<br/>
 _Environment:_
 * PATH: contains location of docker-compose.exe
+
+## Powershell Core
+
+_Version:_ 6.1.2
+<br/>
 
 ## Docker images
 
 The following container images have been cached:
-* microsoft/aspnet:(sha256:5afdec531eaa50f43c0f513355894fbe93398cec877910cc083ae1eb19a38f37)
-* microsoft/dotnet-framework:(sha256:ae13dc81c3778ee8542a3b69abad2100e6d2c77cd1869c3faca7fe278ea6f2ea)
-* microsoft/windowsservercore:(sha256:c60a7376f5147e40b65c51fce34ac17710742f97e91b5c3a71e1667e671112f1)
-* microsoft/nanoserver:(sha256:543145e7387282a60b3d357cd7a9f2c697d52bc45496145f0dcd6bb570ca122e)
-* microsoft/aspnetcore-build:(sha256:9ecc7c5a8a7a11dca5f08c860165646cb30d084606360a3a72b9cbe447241c0c)
+* microsoft/dotnet-framework@sha256:f937dbfb092e5a04ca6ac93d49ab0b6c375bdaf9cd4d9f7bd9d4a9407eb36585
+* microsoft/windowsservercore@sha256:05de0a0ac13d3652bd1f2281b8589459ebb611092e3fe4d8f1be91f1f6984266
+* microsoft/aspnet@sha256:a4d6856b978e5b9858ca294c97c5f4bc9ecfe3b062a7a015eaf625801573bc11
+* microsoft/nanoserver@sha256:2b783310e6c82de737e893abd53ae238ca56b5a96e2861558fb9a111d6691ddb
+* microsoft/aspnetcore-build@sha256:9ecc7c5a8a7a11dca5f08c860165646cb30d084606360a3a72b9cbe447241c0c
 
 ## Visual Studio 2017 Enterprise
 
-_Version:_ VisualStudio/15.8.5+28010.2036<br/>
+_Version:_ VisualStudio/15.9.6+28307.344<br/>
 _Location:_ C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise
 
 The following workloads including required and recommended components are installed with Visual Studio 2017:
@@ -109,10 +115,18 @@ In addition the following optional components are installed:
 * Microsoft.VisualStudio.ComponentGroup.NativeDesktop.WinXP
 * Microsoft.VisualStudio.ComponentGroup.ArchitectureTools.Managed
 * Microsoft.Component.Blend.SDK.WPF
+* Microsoft.Component.VC.Runtime.UCRTSDK
+* Microsoft.VisualStudio.Component.VC.ATL.Spectre
+* Microsoft.VisualStudio.Component.VC.ATLMFC.Spectre
+* Microsoft.VisualStudio.Component.Windows10SDK.17134
+* Microsoft.VisualStudio.Component.Windows10SDK.17763
+* Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre
+* Microsoft.VisualStudio.Component.VC.Runtimes.ARM.Spectre
+* Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre
 
 ## SQL Server Data Tools for VS 2017
 
-_Version:_ 15.1.61808.7030<br/>
+_Version:_ 15.1.61901.3230<br/>
 
 The following components are installed:
 
@@ -132,10 +146,14 @@ _Environment:_
 
 _Version:_ 4.7.03062
 
+## Windows Driver Kit
+
+_Version:_ 10.0.17763.0<br/>
+
 ## Azure Service Fabric
 
-_SDK Version:_ 3.2.176.9494<br/>
-_Runtime Version:_ 6.3.176.9494
+_SDK Version:_ 3.3.617.9590<br/>
+_Runtime Version:_ 6.4.617.9590
 
 ## Python (64 bit)
 
@@ -147,7 +165,23 @@ _Environment:_
 
 _Location:_ C:\Python27amd64
 
+## WinAppDriver
+
+_Version:_ 1.1.1809.18001<br/>
+
 ## Android SDK Build Tools
+
+#### 28.0.3
+
+_Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\28.0.3
+
+#### 28.0.2
+
+_Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\28.0.2
+
+#### 28.0.1
+
+_Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\28.0.1
 
 #### 28.0.0
 
@@ -157,29 +191,73 @@ _Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\28.0.0
 
 _Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\27.0.3
 
+#### 27.0.2
+
+_Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\27.0.2
+
 #### 27.0.1
 
 _Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\27.0.1
+
+#### 27.0.0
+
+_Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\27.0.0
 
 #### 26.0.3
 
 _Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\26.0.3
 
+#### 26.0.2
+
+_Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\26.0.2
+
 #### 26.0.1
 
 _Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\26.0.1
+
+#### 26.0.0
+
+_Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\26.0.0
 
 #### 25.0.3
 
 _Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\25.0.3
 
+#### 25.0.2
+
+_Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\25.0.2
+
+#### 25.0.1
+
+_Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\25.0.1
+
+#### 25.0.0
+
+_Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\25.0.0
+
 #### 24.0.3
 
 _Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\24.0.3
 
+#### 24.0.2
+
+_Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\24.0.2
+
+#### 24.0.1
+
+_Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\24.0.1
+
+#### 24.0.0
+
+_Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\24.0.0
+
 #### 23.0.3
 
 _Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\23.0.3
+
+#### 23.0.2
+
+_Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\23.0.2
 
 #### 23.0.1
 
@@ -193,13 +271,13 @@ _Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\22.0.1
 
 _Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\21.1.2
 
+#### 20.0.0
+
+_Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\20.0.0
+
 #### 19.1.0
 
 _Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\19.1.0
-
-#### 17.0.0
-
-_Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\17.0.0
 
 
 ## Android SDK Platforms
@@ -240,18 +318,6 @@ _Location:_ C:\Program Files (x86)\Android\android-sdk\platforms\android-21
 
 _Location:_ C:\Program Files (x86)\Android\android-sdk\platforms\android-19
 
-#### 4.2.2 (API 17)
-
-_Location:_ C:\Program Files (x86)\Android\android-sdk\platforms\android-17
-
-#### 4.0.3 (API 15)
-
-_Location:_ C:\Program Files (x86)\Android\android-sdk\platforms\android-15
-
-#### 2.3.3 (API 10)
-
-_Location:_ C:\Program Files (x86)\Android\android-sdk\platforms\android-10
-
 
 ## Azure/AzureRM Powershell modules
 
@@ -280,48 +346,56 @@ This version is saved but not installed
 _Location:_ C:\Modules\azurerm_6.7.0\AzureRM\6.7.0\AzureRM.psd1
 
 
+## TLS12
+
+_Version:_ 1.2<br/>
+_Description:_ .NET has been configured to use TLS 1.2 by default
+
 ## Azure CLI
 
-_Version:_ 2.0.46<br/>
+_Version:_ 2.0.57<br/>
 _Environment:_
 * PATH: contains location of az.cmd
 
 ## Python
 
-_Version:_ 2.7.14 (x86)<br/>_Version:_ 3.4.4 (x86)<br/>_Version:_ 3.5.4 (x86)<br/>_Version:_ 3.6.4 (x86)<br/>_Version:_ 3.7.0 (x86)<br/>_Version:_ 2.7.14 (x64)<br/>_Version:_ 3.4.4 (x64)<br/>_Version:_ 3.5.4 (x64)<br/>_Version:_ 3.6.4 (x64)<br/>_Version:_ 3.7.0 (x64)<br/><br/>
+_Version:_ 2.7.14 (x86)<br/>_Version:_ 3.4.4 (x86)<br/>_Version:_ 3.5.4 (x86)<br/>_Version:_ 3.6.8 (x86)<br/>_Version:_ 3.7.2 (x86)<br/>_Version:_ 2.7.14 (x64)<br/>_Version:_ 3.4.4 (x64)<br/>_Version:_ 3.5.4 (x64)<br/>_Version:_ 3.6.8 (x64)<br/>_Version:_ 3.7.2 (x64)<br/><br/>
 > Note: These versions of Python are available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task.
 
 ## Git
 
-_Version:_ 2.19.0<br/>
+_Version:_ 2.20.1<br/>
 _Environment:_
 * PATH: contains location of git.exe
 
-## Git LFS
+## Git Large File Storage (LFS)
 
-_Version:_ 2.5.1<br/>
+_Version:_ 2.6.1<br/>
 _Environment:_
 * PATH: contains location of git-lfs.exe
 * GIT_LFS_PATH: location of git-lfs.exe
 
 ## Go (x64)
 
-#### 1.11
+#### 1.11.5
 
 _Environment:_
-* PATH: contains the location of go.exe version 1.11
-* GOROOT: root directory of the Go 1.11 installation
-* GOROOT_1_11_X64: root directory of the Go 1.11 installation
+* GOROOT_1_9_X64: root directory of the Go 1.11.5 installation
 
-#### 1.10
+#### 1.11.5
 
 _Environment:_
-* GOROOT_1_10_X64: root directory of the Go 1.10 installation
+* PATH: contains the location of go.exe version 1.11.5
+* GOROOT: root directory of the Go 1.11.5 installation
+* GOROOT_1_10_X64: root directory of the Go 1.11.5 installation
 
-#### 1.9
+## PHP (x64)
+
+#### 7.3.1
 
 _Environment:_
-* GOROOT_1_9_X64: root directory of the Go 1.9 installation
+* PATH: contains the location of php.exe version 7.3.1
+* PHPROOT: root directory of the PHP 7.3.1 installation
 
 ## Ruby (x64)
 
@@ -344,12 +418,12 @@ _Environment:_
 ## Google Chrome
 
 _version:_
-68.0.3440.106
+71.0.3578.98
 
 ## Mozilla Firefox
 
 _version:_
-61.0.2
+64.0.2
 
 ## Selenium Web Drivers
 
@@ -357,7 +431,7 @@ _version:_
 #### Chrome Driver
 
 _version:_
-2.40
+2.45
 
 _Environment:_
 * ChromeWebDriver: location of chromedriver.exe
@@ -365,7 +439,7 @@ _Environment:_
 #### Gecko Driver
 
 _version:_
-0.19.1
+0.23.0
 
 _Environment:_
 * GeckoWebDriver: location of geckodriver.exe
@@ -381,30 +455,33 @@ _Environment:_
 
 ## Node.js
 
-_Version:_ 10.15.0<br/>
-_Architecture:_ x64<br/>
+_Version:_ 10.15.1<br/>
 _Environment:_
 * PATH: contains location of node.exe<br/>
+* Gulp [[90m23:15:50[39m] CLI version 2.0.1<br/>
+* Grunt grunt-cli v1.3.2<br/>
+* Bower 1.8.8<br/>
+* Yarn 1.13.0<br/>
 
 > Note: You can install and use another version of Node.js on Microsoft-hosted agent pools using the [Node tool installer](https://docs.microsoft.com/vsts/pipelines/tasks/tool/node-js) task.
 
 ## npm
 
-_Version:_ 6.5.0<br/>
+_Version:_ 6.7.0<br/>
 _Environment:_
 * PATH: contains location of npm.cmd
 
 ## Java Development Kit
 
-#### 1.8.0_181
+#### 1.8.0_202
 
 _Environment:_
 * JAVA_HOME: location of JDK
 * PATH: contains bin folder of JDK
 
-#### 10.0.2
+#### 11.0.2
 
-_Location:_ C:\Program Files\Java\jdk-10.0.2
+_Location:_ C:\Program Files\Java\zulu-11-azure-jdk_11.29.3-11.0.2-win_x64
 
 ## Ant
 
@@ -416,26 +493,26 @@ _Environment:_
 
 ## Maven
 
-_Version:_ 3.5.4<br/>
+_Version:_ 3.6.0<br/>
 _Environment:_
 * PATH: contains location of mvn.bat
 * M2_HOME: Maven installation root
 
 ## Gradle
 
-_Version:_ 4.10.2<br/>
+_Version:_ 5.2<br/>
 _Environment:_
 * PATH: contains location of gradle
 
 ## Cmake
 
-_Version:_ 3.12.2<br/>
+_Version:_ 3.13.4<br/>
 _Environment:_
 * PATH: contains location of cmake.exe
 
 ## SQL Server Data Tier Application Framework (x64)
 
-_Version:_ 14.0.3917.1<br/>
+_Version:_ 15.0.4200.1<br/>
 
 ## .NET Core
 
@@ -445,6 +522,13 @@ _Environment:_
 * PATH: contains location of dotnet.exe
 
 _SDK:_
+* 2.2.103 C:\Program Files\dotnet\sdk\2.2.103
+* 2.2.102 C:\Program Files\dotnet\sdk\2.2.102
+* 2.2.101 C:\Program Files\dotnet\sdk\2.2.101
+* 2.2.100 C:\Program Files\dotnet\sdk\2.2.100
+* 2.1.503 C:\Program Files\dotnet\sdk\2.1.503
+* 2.1.502 C:\Program Files\dotnet\sdk\2.1.502
+* 2.1.500 C:\Program Files\dotnet\sdk\2.1.500
 * 2.1.403 C:\Program Files\dotnet\sdk\2.1.403
 * 2.1.402 C:\Program Files\dotnet\sdk\2.1.402
 * 2.1.401 C:\Program Files\dotnet\sdk\2.1.401
@@ -476,6 +560,10 @@ _SDK:_
 * 1.0.1 C:\Program Files\dotnet\sdk\1.0.1
 
 _Runtime:_
+* 2.2.1 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.2.1
+* 2.2.0 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.2.0
+* 2.1.7 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.7
+* 2.1.6 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.6
 * 2.1.5 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.5
 * 2.1.4 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.4
 * 2.1.3 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.3
@@ -507,39 +595,75 @@ _Runtime:_
 * 1.0.11 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.0.11
 * 1.0.10 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.0.10
 
-## Mercurial
-_Version:_ 4.6.1<br/>
-_Environment:_
-* PATH: contains location of hg.exe
-
 ## Mysql
 
 _Version:_ 5.7.21.0<br/>
 _Environment:_
 * PATH: contains location of mysql.exe
 
-## TLS12
+## SQLPS
 
-_Version:_ 1.2<br/>
-_Description:_ .NET has been configured to use TLS 1.2 by default
+_Version:_ 1.0
+
+## SQLServer PS
+
+_Version:_ 21.1.18080
 
 ## MinGW
 
-_Version:_ 5.3.0<br/>
+_Version:_ 8.1.0<br/>
 _Environment:_
 * PATH: contains location of the MinGW 'bin' directory
 
 ## TypeScript
 
-_Version:_ Version 3.0.3<br/>
+_Version:_ Version 3.3.3<br/>
 
 ## Miniconda
 
-_Version:_ conda 4.5.11<br/>
+_Version:_ conda 4.5.12<br/>
 _Environment:_
 * CONDA: contains location of the root of the Miniconda installation
 
 ## Azure CosmosDb Emulator
 
-_Version:_ 2.0.0.0<br/>
-_Location:_ C:\Program Files\Azure Cosmos DB Emulator
+_Version:_ 2.1.4.0<br/>
+_Location:_ C:\Program Files\Azure Cosmos DB Emulator\
+
+## 7zip
+
+_Version:_ 18.06<br/>
+
+## Mercurial
+
+_Version:_ <br/>
+
+## jq
+
+_Version:_ jq-1.5<br/>
+
+## Inno Setup
+
+_Version:_ 5.6.1<br/>
+
+## Perl
+
+_Version:_ v5.26.2<br/>
+
+## GitVersion
+
+_Version:_ 4.0.0.0<br/>
+
+## OpenSSL
+
+_Version:_ 1.1.1a at C:\Program Files\Git\usr\bin\openssl.exe<br/>_Version:_ 1.1.1a at C:\Program Files\Git\mingw64\bin\openssl.exe<br/>_Version:_ 1.0.2j at C:\Program Files (x86)\Subversion\bin\openssl.exe<br/>_Version:_ 1.1.0i at C:\Strawberry\c\bin\openssl.exe<br/>_Version:_ 1.1.1 at C:\Program Files\OpenSSL\bin\openssl.exe<br/>
+
+## Cloud Foundry CLI
+
+_Version:_ 6.42.0<br/>
+
+## Vcpkg
+
+_Version:_ 2018.11.23-nohash<br/>
+_Environment:_
+* PATH: contains location of the vcpkg directory


### PR DESCRIPTION
Properly adds the Vs2017-Server2016-Readme.md file for the 148.1 VS2017 image update to master. This file was not updated by mistake in master. It's already in the releases/VS2017/148.1 release branch.