### PR TITLE
Don't install python with VS, use versions in tools cache

### DIFF
--- a/images/win/scripts/Installers/Validate-Python.ps1
+++ b/images/win/scripts/Installers/Validate-Python.ps1
@@ -15,9 +15,9 @@ else
     exit 1
 }
 
-$Python3Verison = $(python --version)
+$Python3Version = $(python --version)
 
-if ($Python3Verison -notlike "Python 3.*")
+if ($Python3Version -notlike "Python 3.*")
 {
     Write-Error "Python 3 is not in the PATH"
 }
@@ -31,7 +31,7 @@ $Python2Version = & $env:comspec "/s /c python --version 2>&1"
 $SoftwareName = "Python (64 bit)"
 
 $Description = @"
-#### $Python3Verison
+#### $Python3Version
 _Environment:_
 * PATH: contains location of python.exe
 

--- a/images/win/scripts/Installers/Validate-Python.ps1
+++ b/images/win/scripts/Installers/Validate-Python.ps1
@@ -1,8 +1,8 @@
 ################################################################################
 ##  File:  Validate-Python.ps1
 ##  Team:  CI-X
-##  Desc:  Configure python on path based on what VS installs
-##         Must run after VS is installed
+##  Desc:  Configure python on path based on what is installed in the tools cache
+##         Must run after tools cache is downloaded and validated
 ################################################################################
 
 if(Get-Command -Name 'python')
@@ -11,11 +11,16 @@ if(Get-Command -Name 'python')
 }
 else
 {
-     Write-Host "Python is not on path"
+    Write-Host "Python is not on path"
     exit 1
 }
 
 $Python3Verison = $(python --version)
+
+if ($Python3Verison -notlike "Python 3.*")
+{
+    Write-Error "Python 3 is not in the PATH"
+}
 
 $Python2Path = "C:\Python27amd64"
 $env:Path = $Python2Path + ";" + $env:Path

--- a/images/win/scripts/Installers/Vs2017/Install-Python.ps1
+++ b/images/win/scripts/Installers/Vs2017/Install-Python.ps1
@@ -1,17 +1,18 @@
 ################################################################################
 ##  File:  Install-Python.ps1
 ##  Team:  CI-X
-##  Desc:  Configure python on path based on what VS installs
-##         Must run after VS is installed
+##  Desc:  Configure python on path with 3.6.* version from the tools cache
+##         Must run after tools cache is setup
 ################################################################################
 
 Import-Module -Name ImageHelpers -Force
 
-$pythonDir = Get-Item -Path 'C:\Program Files (x86)\Microsoft Visual Studio\Shared\Python3*'
+$python36path = $Env:AGENT_TOOLSDIRECTORY + '/Python/3.6*'
+$pythonDir = Get-Item -Path $python36path
 
 if($pythonDir -is [array])
 {
-    Write-Host "More than one python 3 install found"
+    Write-Host "More than one python 3.6.* installations found"
     Write-Host $pythonDir
     exit 1
 }
@@ -20,10 +21,9 @@ $currentPath = Get-MachinePath
 
 if ($currentPath | Select-String -SimpleMatch $pythonDir.FullName)
 {
-    Write-Host $pythonDir.FullName ' is already in path'
+    Write-Host $pythonDir.FullName ' is already in PATH'
     exit 0
 }
 
 Add-MachinePathItem -PathItem $pythonDir.FullName
 Add-MachinePathItem -PathItem "$($pythonDir.FullName)\Scripts"
-setx PYTHON_HOME $pythonDir.FullName /M

--- a/images/win/scripts/Installers/Vs2017/Install-VS2017.ps1
+++ b/images/win/scripts/Installers/Vs2017/Install-VS2017.ps1
@@ -92,6 +92,7 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
                 '--add Microsoft.VisualStudio.Web.Mvc4.ComponentGroup ' + `
                 '--add Component.CPython2.x64 ' + `
                 '--add Microsoft.Component.PythonTools.UWP ' + `
+                '–-remove Component.CPython3.x64 ' + `
                 '--add Microsoft.Component.VC.Runtime.OSSupport ' + `
                 '--add Microsoft.VisualStudio.Component.VC.Tools.ARM ' + `
                 '--add Microsoft.VisualStudio.ComponentGroup.UWP.VC ' + `

--- a/images/win/scripts/Installers/Vs2019/Install-Python.ps1
+++ b/images/win/scripts/Installers/Vs2019/Install-Python.ps1
@@ -1,17 +1,18 @@
 ################################################################################
 ##  File:  Install-Python.ps1
 ##  Team:  CI-X
-##  Desc:  Configure python on path based on what VS installs
-##         Must run after VS is installed
+##  Desc:  Configure python on path with 3.7.* version from the tools cache
+##         Must run after tools cache is setup
 ################################################################################
 
 Import-Module -Name ImageHelpers -Force
 
-$pythonDir = Get-Item -Path 'C:\Program Files (x86)\Microsoft Visual Studio\Shared\Python3*'
+$python37path = $Env:AGENT_TOOLSDIRECTORY + '/Python/3.7*'
+$pythonDir = Get-Item -Path $python37path
 
 if($pythonDir -is [array])
 {
-    Write-Host "More than one python 3 install found"
+    Write-Host "More than one python 3.7.* installations found"
     Write-Host $pythonDir
     exit 1
 }
@@ -20,10 +21,9 @@ $currentPath = Get-MachinePath
 
 if ($currentPath | Select-String -SimpleMatch $pythonDir.FullName)
 {
-    Write-Host $pythonDir.FullName ' is already in path'
+    Write-Host $pythonDir.FullName ' is already in PATH'
     exit 0
 }
 
 Add-MachinePathItem -PathItem $pythonDir.FullName
 Add-MachinePathItem -PathItem "$($pythonDir.FullName)\Scripts"
-setx PYTHON_HOME $pythonDir.FullName /M

--- a/images/win/scripts/Installers/Vs2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Vs2019/Install-VS2019.ps1
@@ -63,7 +63,6 @@ Function InstallVS
 
 $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Component.CPython2.x64 ' + `
-              '--add Component.CPython3.x64 ' + `
               '--add Component.Linux.CMake ' + `
               '--add Component.UnityEngine.x64 ' + `
               '--add Component.UnityEngine.x86 ' + `

--- a/images/win/scripts/Installers/Vs2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Vs2019/Install-VS2019.ps1
@@ -125,6 +125,7 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Workload.Node ' + `
               '--add Microsoft.VisualStudio.Workload.Office ' + `
               '--add Microsoft.VisualStudio.Workload.Python ' + `
+              '–-remove Component.CPython3.x64 ' + `
               '--add Microsoft.VisualStudio.Workload.Universal ' + `
               '--add Microsoft.VisualStudio.Workload.VisualStudioExtension'
 

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -191,12 +191,6 @@
             ]
         },
         {
-            "type": "powershell",
-            "scripts":[
-                "{{ template_dir }}/scripts/Installers/Vs2017/Install-Python.ps1"
-            ]
-        },
-        {
             "type": "windows-restart",
             "restart_timeout": "30m"
         },
@@ -233,12 +227,6 @@
         {
             "type": "powershell",
             "scripts":[
-                "{{ template_dir }}/scripts/Installers/Validate-Python.ps1"
-            ]
-        },
-        {
-            "type": "powershell",
-            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Update-DotnetTLS.ps1"
             ]
         },
@@ -258,6 +246,12 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Download-ToolCache.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Vs2017/Install-Python.ps1"
             ]
         },
         {
@@ -522,6 +516,12 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-ToolCache.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-Python.ps1"
             ]
         },
         {

--- a/images/win/vs2019-Server2019-Azure.json
+++ b/images/win/vs2019-Server2019-Azure.json
@@ -171,12 +171,6 @@
             ]
         },
         {
-            "type": "powershell",
-            "scripts":[
-                "{{ template_dir }}/scripts/Installers/Vs2019/Install-Python.ps1"
-            ]
-        },
-        {
             "type": "windows-restart",
             "restart_timeout": "10m"
         },
@@ -207,12 +201,6 @@
         {
             "type": "powershell",
             "scripts":[
-                "{{ template_dir }}/scripts/Installers/Validate-Python.ps1"
-            ]
-        },
-        {
-            "type": "powershell",
-            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Update-DotnetTLS.ps1"
             ]
         },
@@ -232,6 +220,12 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Download-ToolCache.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Vs2019/Install-Python.ps1"
             ]
         },
         {
@@ -490,6 +484,12 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-ToolCache.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-Python.ps1"
             ]
         },
         {


### PR DESCRIPTION
https://github.com/Microsoft/azure-pipelines-image-generation/issues/756
- Remove Python 3 from VS installation (after discussing with Steve Dower)
- Use Python 3 from the tools cache, using python 3.6 for VS2017 and python 3.7 for VS 2019

Testing: Generated VS2019 and VS2017 successfully with these changes.