### PR TITLE
Add Windows SDK 16299 to VS2019 image

### DIFF
--- a/images/win/scripts/Installers/Vs2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Vs2019/Install-VS2019.ps1
@@ -106,6 +106,7 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Component.VC.TestAdapterForBoostTest ' + `
               '--add Microsoft.VisualStudio.Component.VC.TestAdapterForGoogleTest ' + `
               '--add Microsoft.VisualStudio.Component.VC.v141 ' + `
+              '--add Microsoft.VisualStudio.Component.Windows10SDK.16299 ' + `
               '--add Microsoft.VisualStudio.Component.Windows10SDK.17134 ' + `
               '--add Microsoft.VisualStudio.Component.Windows10SDK.17763 ' + `
               '--add Microsoft.VisualStudio.ComponentGroup.Azure.CloudServices ' + `


### PR DESCRIPTION
This addresses 16299 missing from the Visual Studio 2019 image, as mentioned in https://github.com/Microsoft/azure-pipelines-image-generation/issues/734