### PR TITLE
Rename predefined  environment variable  $VCPKG_ROOT to $VCPKG_INSTALLATION_ROOT

### DIFF
--- a/images/linux/scripts/installers/vcpkg.sh
+++ b/images/linux/scripts/installers/vcpkg.sh
@@ -14,7 +14,7 @@ echo "VCPKG_INSTALLATION_ROOT=${VCPKG_INSTALLATION_ROOT}" | tee -a /etc/environm
 
 # Install vcpkg
 git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT
-chmod 0755 $VCPKG_INSTALLATION_ROOT
+chmod 0777 -R $VCPKG_INSTALLATION_ROOT
 $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh
 $VCPKG_INSTALLATION_ROOT/vcpkg integrate install
 ln -sf $VCPKG_INSTALLATION_ROOT/vcpkg /usr/local/bin

--- a/images/linux/scripts/installers/vcpkg.sh
+++ b/images/linux/scripts/installers/vcpkg.sh
@@ -9,15 +9,15 @@
 source $HELPER_SCRIPTS/document.sh
 
 # Set env variable for vcpkg
-VCPKG_ROOT=/usr/local/share/vcpkg
-echo "VCPKG_ROOT=${VCPKG_ROOT}" | tee -a /etc/environment
+VCPKG_INSTALLATION_ROOT=/usr/local/share/vcpkg
+echo "VCPKG_INSTALLATION_ROOT=${VCPKG_INSTALLATION_ROOT}" | tee -a /etc/environment
 
 # Install vcpkg
-git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_ROOT
-chmod 0755 $VCPKG_ROOT
-$VCPKG_ROOT/bootstrap-vcpkg.sh
-$VCPKG_ROOT/vcpkg integrate install
-ln -sf $VCPKG_ROOT/vcpkg /usr/local/bin
+git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT
+chmod 0755 $VCPKG_INSTALLATION_ROOT
+$VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh
+$VCPKG_INSTALLATION_ROOT/vcpkg integrate install
+ln -sf $VCPKG_INSTALLATION_ROOT/vcpkg /usr/local/bin
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"

--- a/images/win/scripts/Installers/Install-Vcpkg.ps1
+++ b/images/win/scripts/Installers/Install-Vcpkg.ps1
@@ -19,4 +19,4 @@ Invoke-Expression "$InstallDir\$VcpkgExecPath integrate install"
 # Add vcpkg to system environment
 Add-MachinePathItem $InstallDir
 $env:Path = Get-MachinePath
-setx VCPKG_ROOT $InstallDir /M
+setx VCPKG_INSTALLATION_ROOT $InstallDir /M

--- a/images/win/scripts/Installers/Validate-Vcpkg.ps1
+++ b/images/win/scripts/Installers/Validate-Vcpkg.ps1
@@ -15,14 +15,14 @@ else
     exit 1
 }
 
-if ($env:VCPKG_ROOT) 
+if ($env:VCPKG_INSTALLATION_ROOT) 
 {
-    Write-Host "The VCPKG_ROOT environment variable is set"
-    Write-Host $env:VCPKG_ROOT
+    Write-Host "The VCPKG_INSTALLATION_ROOT environment variable is set"
+    Write-Host $env:VCPKG_INSTALLATION_ROOT
 }
 else
 {
-    Write-Host "The VCPKG_ROOT environment variable is not set"
+    Write-Host "The VCPKG_INSTALLATION_ROOT environment variable is not set"
     exit 1
 }
 
@@ -41,7 +41,7 @@ $Description = @"
 _Version:_ $VcpkgVersion<br/>
 _Environment:_
 * PATH: contains location of the vcpkg directory
-* VCPKG_ROOT: root directory of the vcpkg installation
+* VCPKG_INSTALLATION_ROOT: root directory of the vcpkg installation
 "@
 
 Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description


### PR DESCRIPTION
Fix for the issue [#769](https://github.com/Microsoft/azure-pipelines-image-generation/issues/769) : Rename env $VCPKG_ROOT to $VCPKG_INSTALLATION_ROOT to prevent user environment variable overriding.

 **Ubuntu 16.04 (vcpkg.sh) changes:**
       - Rename $VCPKG_ROOT to $VCPKG_INSTALLATION_ROOT 
       - Add folder permissions ( chmod 0777 -R $VCPKG_INSTALLATION_ROOT ) to allow users to install vcpkg  packages in $VCPKG_INSTALLATION_ROOT

**Windows**(Install-Vcpkg/Validate-Vcpkg.ps1) changes: to preserve consistency with linux, rename $VCPKG_ROOT to $VCPKG_INSTALLATION_ROOT