### PR TITLE
remove bad character introduced by copy paste for -

### DIFF
--- a/images/win/scripts/Installers/Vs2017/Install-VS2017.ps1
+++ b/images/win/scripts/Installers/Vs2017/Install-VS2017.ps1
@@ -92,7 +92,7 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
                 '--add Microsoft.VisualStudio.Web.Mvc4.ComponentGroup ' + `
                 '--add Component.CPython2.x64 ' + `
                 '--add Microsoft.Component.PythonTools.UWP ' + `
-                '–-remove Component.CPython3.x64 ' + `
+                '--remove Component.CPython3.x64 ' + `
                 '--add Microsoft.Component.VC.Runtime.OSSupport ' + `
                 '--add Microsoft.VisualStudio.Component.VC.Tools.ARM ' + `
                 '--add Microsoft.VisualStudio.ComponentGroup.UWP.VC ' + `

--- a/images/win/scripts/Installers/Vs2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Vs2019/Install-VS2019.ps1
@@ -125,7 +125,7 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Workload.Node ' + `
               '--add Microsoft.VisualStudio.Workload.Office ' + `
               '--add Microsoft.VisualStudio.Workload.Python ' + `
-              '–-remove Component.CPython3.x64 ' + `
+              '--remove Component.CPython3.x64 ' + `
               '--add Microsoft.VisualStudio.Workload.Universal ' + `
               '--add Microsoft.VisualStudio.Workload.VisualStudioExtension'
 


### PR DESCRIPTION
We are removing Python 3.* install to avoid conflicts with python installs in the tools cache in VS2019 and VS2017. There is a bad character in the script causing VS install to fail. Replacing that with the right hyphen character