### PR TITLE
Put PyPy versions in Agent.ToolsDirectory

### DIFF
--- a/images/linux/scripts/installers/python.sh
+++ b/images/linux/scripts/installers/python.sh
@@ -11,19 +11,33 @@ source $HELPER_SCRIPTS/document.sh
 # Install Python, Python 3, pip, pip3
 apt-get install -y --no-install-recommends python python-dev python-pip python3 python3-dev python3-pip
 
-# Instally PyPy2
+# Install PyPy2 to $AGENT_TOOLSDIRECTORY
 wget -q -P /tmp https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-linux64.tar.bz2
-tar -x -C /opt -f /tmp/pypy2-v6.0.0-linux64.tar.bz2
+tar -x -C /tmp -f /tmp/pypy2-v6.0.0-linux64.tar.bz2
 rm /tmp/pypy2-v6.0.0-linux64.tar.bz2
-mv /opt/pypy2-v6.0.0-linux64 /opt/pypy2
-ln -s /opt/pypy2/bin/pypy /usr/local/bin/pypy
+mv /tmp/pypy2-v6.0.0-linux64 $AGENT_TOOLSDIRECTORY/PyPy2/6.0.0/x64
+touch $AGENT_TOOLSDIRECTORY/PyPy2/6.0.0/x64.complete
 
-# Install PyPy3
+# add pypy to PATH by default
+ln -s $AGENT_TOOLSDIRECTORY/PyPy2/6.0.0/x64/bin/pypy /usr/local/bin/pypy
+# pypy will be the python in PATH when its tools cache directory is prepended to PATH
+# PEP 394-style symlinking; don't bother with minor version
+ln -s $AGENT_TOOLSDIRECTORY/PyPy2/6.0.0/x64/bin/pypy $AGENT_TOOLSDIRECTORY/PyPy2/6.0.0/x64/bin/python2
+ln -s $AGENT_TOOLSDIRECTORY/PyPy2/6.0.0/x64/bin/python2 $AGENT_TOOLSDIRECTORY/PyPy2/6.0.0/x64/bin/python
+
+# Install PyPy3 to $AGENT_TOOLSDIRECTORY
 wget -q -P /tmp https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-linux64.tar.bz2
-tar -x -C /opt -f /tmp/pypy3-v6.0.0-linux64.tar.bz2
+tar -x -C /tmp -f /tmp/pypy3-v6.0.0-linux64.tar.bz2
 rm /tmp/pypy3-v6.0.0-linux64.tar.bz2
-mv /opt/pypy3-v6.0.0-linux64 /opt/pypy3
-ln -s /opt/pypy3/bin/pypy3 /usr/local/bin/pypy3
+mv /tmp/pypy3-v6.0.0-linux64 $AGENT_TOOLSDIRECTORY/PyPy3/6.0.0/x64
+touch $AGENT_TOOLSDIRECTORY/PyPy3/6.0.0/x64.complete
+
+# add pypy3 to PATH by default
+ln -s $AGENT_TOOLSDIRECTORY/PyPy3/6.0.0/x64/bin/pypy3 /usr/local/bin/pypy3
+# pypy3 will be the python in PATH when its tools cache directory is prepended to PATH
+# PEP 394-style symlinking; don't bother with minor version
+ln -s $AGENT_TOOLSDIRECTORY/PyPy3/6.0.0/x64/bin/pypy3 $AGENT_TOOLSDIRECTORY/PyPy3/6.0.0/x64/bin/python3
+ln -s $AGENT_TOOLSDIRECTORY/PyPy3/6.0.0/x64/bin/python3 $AGENT_TOOLSDIRECTORY/PyPy3/6.0.0/x64/bin/python
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"

--- a/images/linux/scripts/installers/python.sh
+++ b/images/linux/scripts/installers/python.sh
@@ -11,33 +11,35 @@ source $HELPER_SCRIPTS/document.sh
 # Install Python, Python 3, pip, pip3
 apt-get install -y --no-install-recommends python python-dev python-pip python3 python3-dev python3-pip
 
-# Install PyPy2 to $AGENT_TOOLSDIRECTORY
-wget -q -P /tmp https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-linux64.tar.bz2
-tar -x -C /tmp -f /tmp/pypy2-v6.0.0-linux64.tar.bz2
-rm /tmp/pypy2-v6.0.0-linux64.tar.bz2
-mv /tmp/pypy2-v6.0.0-linux64 $AGENT_TOOLSDIRECTORY/PyPy2/6.0.0/x64
-touch $AGENT_TOOLSDIRECTORY/PyPy2/6.0.0/x64.complete
+# Install PyPy 2.7 to $AGENT_TOOLSDIRECTORY
+wget -q -P /tmp https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.1.0-linux64.tar.bz2
+tar -x -C /tmp -f /tmp/pypy2.7-v7.1.0-linux64.tar.bz2
+rm /tmp/pypy2.7-v7.1.0-linux64.tar.bz2
+mkdir -p $AGENT_TOOLSDIRECTORY/PyPy/2.7.13
+mv /tmp/pypy2.7-v7.1.0-linux64 $AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64
+touch $AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64.complete
 
 # add pypy to PATH by default
-ln -s $AGENT_TOOLSDIRECTORY/PyPy2/6.0.0/x64/bin/pypy /usr/local/bin/pypy
+ln -s $AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64/bin/pypy /usr/local/bin/pypy
 # pypy will be the python in PATH when its tools cache directory is prepended to PATH
 # PEP 394-style symlinking; don't bother with minor version
-ln -s $AGENT_TOOLSDIRECTORY/PyPy2/6.0.0/x64/bin/pypy $AGENT_TOOLSDIRECTORY/PyPy2/6.0.0/x64/bin/python2
-ln -s $AGENT_TOOLSDIRECTORY/PyPy2/6.0.0/x64/bin/python2 $AGENT_TOOLSDIRECTORY/PyPy2/6.0.0/x64/bin/python
+ln -s $AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64/bin/pypy $AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64/bin/python2
+ln -s $AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64/bin/python2 $AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64/bin/python
 
-# Install PyPy3 to $AGENT_TOOLSDIRECTORY
-wget -q -P /tmp https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-linux64.tar.bz2
-tar -x -C /tmp -f /tmp/pypy3-v6.0.0-linux64.tar.bz2
-rm /tmp/pypy3-v6.0.0-linux64.tar.bz2
-mv /tmp/pypy3-v6.0.0-linux64 $AGENT_TOOLSDIRECTORY/PyPy3/6.0.0/x64
-touch $AGENT_TOOLSDIRECTORY/PyPy3/6.0.0/x64.complete
+# Install PyPy 3.5 to $AGENT_TOOLSDIRECTORY
+wget -q -P /tmp https://bitbucket.org/pypy/pypy/downloads/pypy3.5-v7.0.0-linux64.tar.bz2
+tar -x -C /tmp -f /tmp/pypy3.5-v7.0.0-linux64.tar.bz2
+rm /tmp/pypy3.5-v7.0.0-linux64.tar.bz2
+mkdir -p $AGENT_TOOLSDIRECTORY/PyPy/3.5.3
+mv /tmp/pypy3.5-v7.0.0-linux64 $AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64
+touch $AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64.complete
 
 # add pypy3 to PATH by default
-ln -s $AGENT_TOOLSDIRECTORY/PyPy3/6.0.0/x64/bin/pypy3 /usr/local/bin/pypy3
+ln -s $AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64/bin/pypy3 /usr/local/bin/pypy3
 # pypy3 will be the python in PATH when its tools cache directory is prepended to PATH
 # PEP 394-style symlinking; don't bother with minor version
-ln -s $AGENT_TOOLSDIRECTORY/PyPy3/6.0.0/x64/bin/pypy3 $AGENT_TOOLSDIRECTORY/PyPy3/6.0.0/x64/bin/python3
-ln -s $AGENT_TOOLSDIRECTORY/PyPy3/6.0.0/x64/bin/python3 $AGENT_TOOLSDIRECTORY/PyPy3/6.0.0/x64/bin/python
+ln -s $AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64/bin/pypy3 $AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64/bin/python3
+ln -s $AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64/bin/python3 $AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64/bin/python
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"

--- a/images/linux/scripts/installers/python.sh
+++ b/images/linux/scripts/installers/python.sh
@@ -26,8 +26,9 @@ ln -s $AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64/bin/pypy /usr/local/bin/pypy
 ln -s $AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64/bin/pypy $AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64/bin/python2
 ln -s $AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64/bin/python2 $AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64/bin/python
 
-# Install Pip for PyPy2
+# Install latest Pip for PyPy2
 $AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64/bin/pypy -m ensurepip
+$AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64/bin/pypy -m pip install --ignore-installed pip
 
 # Install PyPy 3.5 to $AGENT_TOOLSDIRECTORY
 wget -q -P /tmp https://bitbucket.org/pypy/pypy/downloads/pypy3.5-v7.0.0-linux64.tar.bz2
@@ -44,8 +45,9 @@ ln -s $AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64/bin/pypy3 /usr/local/bin/pypy3
 ln -s $AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64/bin/pypy3 $AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64/bin/python3
 ln -s $AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64/bin/python3 $AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64/bin/python
 
-# Install Pip for PyPy3
+# Install latest Pip for PyPy3
 $AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64/bin/pypy3 -m ensurepip
+$AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64/bin/pypy3 -m pip install --ignore-installed pip
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"

--- a/images/linux/scripts/installers/python.sh
+++ b/images/linux/scripts/installers/python.sh
@@ -26,6 +26,9 @@ ln -s $AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64/bin/pypy /usr/local/bin/pypy
 ln -s $AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64/bin/pypy $AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64/bin/python2
 ln -s $AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64/bin/python2 $AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64/bin/python
 
+# Install Pip for PyPy2
+$AGENT_TOOLSDIRECTORY/PyPy/2.7.13/x64/bin/pypy -m ensurepip
+
 # Install PyPy 3.5 to $AGENT_TOOLSDIRECTORY
 wget -q -P /tmp https://bitbucket.org/pypy/pypy/downloads/pypy3.5-v7.0.0-linux64.tar.bz2
 tar -x -C /tmp -f /tmp/pypy3.5-v7.0.0-linux64.tar.bz2
@@ -40,6 +43,9 @@ ln -s $AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64/bin/pypy3 /usr/local/bin/pypy3
 # PEP 394-style symlinking; don't bother with minor version
 ln -s $AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64/bin/pypy3 $AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64/bin/python3
 ln -s $AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64/bin/python3 $AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64/bin/python
+
+# Install Pip for PyPy3
+$AGENT_TOOLSDIRECTORY/PyPy/3.5.3/x64/bin/pypy3 -m ensurepip
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -124,7 +124,6 @@
                 "{{template_dir}}/scripts/installers/php.sh",
                 "{{template_dir}}/scripts/installers/pollinate.sh",
                 "{{template_dir}}/scripts/installers/powershellcore.sh",
-                "{{template_dir}}/scripts/installers/python.sh",
                 "{{template_dir}}/scripts/installers/ruby.sh",
                 "{{template_dir}}/scripts/installers/scala.sh",
                 "{{template_dir}}/scripts/installers/sphinx.sh",
@@ -145,7 +144,8 @@
                 "{{template_dir}}/scripts/installers/android.sh",
                 "{{template_dir}}/scripts/installers/azpowershell.sh",
                 "{{template_dir}}/scripts/helpers/containercache.sh",
-                "{{template_dir}}/scripts/installers/hosted-tool-cache.sh"
+                "{{template_dir}}/scripts/installers/hosted-tool-cache.sh",
+                "{{template_dir}}/scripts/installers/python.sh"
             ],
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",


### PR DESCRIPTION
* Unzip PyPy versions to Agent.ToolsDirectory instead of /opt.  This is for them to be found by Use Python 
Version: see https://github.com/Microsoft/azure-pipelines-tasks/pull/9866
* Update to PyPy v7.0
* Add PEP 394-style symlinking (python -> python3 -> pypy3)
* Install Pip for PyPy versions