### PR TITLE
Added built-in tests for toolcache

### DIFF
--- a/images/linux/scripts/installers/test-toolcache.sh
+++ b/images/linux/scripts/installers/test-toolcache.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+################################################################################
+##  File:  test-toolcache.sh
+##  Team:  CI-Platform
+##  Desc:  Test Python and Ruby versions in tools cache
+################################################################################
+
+# Must be procecessed after tool cache setup(hosted-tool-cache.sh).
+
+# Fail out if any tests fail
+set -e
+
+AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
+
+# Python test
+if [ -d "$AGENT_TOOLSDIRECTORY/Python" ]; then
+   cd $AGENT_TOOLSDIRECTORY/Python
+   python_dirs=($(ls -d */))
+   echo "Python versions folders: ${python_dirs[@]}"
+   echo "------------------------------------------"
+   for version_dir in "${python_dirs[@]}"
+   do
+      echo "Test $AGENT_TOOLSDIRECTORY/Python/$version_dir:"
+      expected_ver=$(echo $version_dir | egrep -o '[0-9]+\.[0-9]+')
+      actual_ver=$($AGENT_TOOLSDIRECTORY/Python/$version_dir/x64/python -c 'import sys;print(sys.version)'| head -1 | egrep -o '[0-9]+\.[0-9]+')
+
+      if [ "$expected_ver" = "$actual_ver" ]; then
+            echo "Passed!"
+      else
+            echo "Expected: $expected_ver; Actual: $actual_ver"
+            exit 1
+      fi
+   done
+else
+   echo "$AGENT_TOOLSDIRECTORY/Python does not exist"
+   exit 1
+fi
+
+# Ruby test
+if [ -d "$AGENT_TOOLSDIRECTORY/Ruby" ]; then
+   cd $AGENT_TOOLSDIRECTORY/Ruby
+   ruby_dirs=($(ls -d */))
+   echo "Ruby versions folders: ${ruby_dirs[@]}"
+   echo "--------------------------------------"
+   for version_dir in "${ruby_dirs[@]}"
+   do
+      echo "Test $AGENT_TOOLSDIRECTORY/Ruby/$version_dir:"
+      expected_ver=$(echo $version_dir | egrep -o '[0-9]+\.[0-9]+')
+      actual_ver=$($AGENT_TOOLSDIRECTORY/Ruby/$version_dir/x64/bin/ruby -e "puts RUBY_VERSION" | egrep -o '[0-9]+\.[0-9]+')
+
+      if [ "$expected_ver" = "$actual_ver" ]; then
+         echo "Passed!"
+      else
+         echo "Expected: $expected_ver; Actual: $actual_ver"
+         exit 1
+      fi
+   done
+else
+   echo "$AGENT_TOOLSDIRECTORY/Ruby does not exist"
+   # exit 1 It's temporary mock until Ruby added to toolcache
+fi

--- a/images/linux/scripts/installers/test-toolcache.sh
+++ b/images/linux/scripts/installers/test-toolcache.sh
@@ -15,7 +15,7 @@ AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
 # Python test
 if [ -d "$AGENT_TOOLSDIRECTORY/Python" ]; then
    cd $AGENT_TOOLSDIRECTORY/Python
-   python_dirs=($(ls -d */))
+   python_dirs=($(find . -mindepth 1 -maxdepth 1 -type d | sed "s|^\./||"))
    echo "Python versions folders: ${python_dirs[@]}"
    echo "------------------------------------------"
    if [ -n "$python_dirs" ]; then
@@ -44,7 +44,7 @@ fi
 # Ruby test
 if [ -d "$AGENT_TOOLSDIRECTORY/Ruby" ]; then
    cd $AGENT_TOOLSDIRECTORY/Ruby
-   ruby_dirs=($(ls -d */))
+   ruby_dirs=($(find . -mindepth 1 -maxdepth 1 -type d | sed "s|^\./||"))
    echo "Ruby versions folders: ${ruby_dirs[@]}"
    echo "--------------------------------------"
    if [ -n "$ruby_dirs" ]; then

--- a/images/linux/scripts/installers/test-toolcache.sh
+++ b/images/linux/scripts/installers/test-toolcache.sh
@@ -18,19 +18,24 @@ if [ -d "$AGENT_TOOLSDIRECTORY/Python" ]; then
    python_dirs=($(ls -d */))
    echo "Python versions folders: ${python_dirs[@]}"
    echo "------------------------------------------"
-   for version_dir in "${python_dirs[@]}"
-   do
-      echo "Test $AGENT_TOOLSDIRECTORY/Python/$version_dir:"
-      expected_ver=$(echo $version_dir | egrep -o '[0-9]+\.[0-9]+')
-      actual_ver=$($AGENT_TOOLSDIRECTORY/Python/$version_dir/x64/python -c 'import sys;print(sys.version)'| head -1 | egrep -o '[0-9]+\.[0-9]+')
+   if [ -n "$python_dirs" ]; then
+      for version_dir in "${python_dirs[@]}"
+      do
+         echo "Test $AGENT_TOOLSDIRECTORY/Python/$version_dir:"
+         expected_ver=$(echo $version_dir | egrep -o '[0-9]+\.[0-9]+')
+         actual_ver=$($AGENT_TOOLSDIRECTORY/Python/$version_dir/x64/python -c 'import sys;print(sys.version)'| head -1 | egrep -o '[0-9]+\.[0-9]+')
 
-      if [ "$expected_ver" = "$actual_ver" ]; then
-            echo "Passed!"
-      else
-            echo "Expected: $expected_ver; Actual: $actual_ver"
-            exit 1
-      fi
-   done
+         if [ "$expected_ver" = "$actual_ver" ]; then
+               echo "Passed!"
+         else
+               echo "Expected: $expected_ver; Actual: $actual_ver"
+               exit 1
+         fi
+      done
+   else
+      echo "$AGENT_TOOLSDIRECTORY/Python does not include any folders"
+      exit 1
+   fi
 else
    echo "$AGENT_TOOLSDIRECTORY/Python does not exist"
    exit 1
@@ -42,19 +47,24 @@ if [ -d "$AGENT_TOOLSDIRECTORY/Ruby" ]; then
    ruby_dirs=($(ls -d */))
    echo "Ruby versions folders: ${ruby_dirs[@]}"
    echo "--------------------------------------"
-   for version_dir in "${ruby_dirs[@]}"
-   do
-      echo "Test $AGENT_TOOLSDIRECTORY/Ruby/$version_dir:"
-      expected_ver=$(echo $version_dir | egrep -o '[0-9]+\.[0-9]+')
-      actual_ver=$($AGENT_TOOLSDIRECTORY/Ruby/$version_dir/x64/bin/ruby -e "puts RUBY_VERSION" | egrep -o '[0-9]+\.[0-9]+')
+   if [ -n "$ruby_dirs" ]; then
+      for version_dir in "${ruby_dirs[@]}"
+      do
+         echo "Test $AGENT_TOOLSDIRECTORY/Ruby/$version_dir:"
+         expected_ver=$(echo $version_dir | egrep -o '[0-9]+\.[0-9]+')
+         actual_ver=$($AGENT_TOOLSDIRECTORY/Ruby/$version_dir/x64/bin/ruby -e "puts RUBY_VERSION" | egrep -o '[0-9]+\.[0-9]+')
 
-      if [ "$expected_ver" = "$actual_ver" ]; then
-         echo "Passed!"
-      else
-         echo "Expected: $expected_ver; Actual: $actual_ver"
-         exit 1
-      fi
-   done
+         if [ "$expected_ver" = "$actual_ver" ]; then
+            echo "Passed!"
+         else
+            echo "Expected: $expected_ver; Actual: $actual_ver"
+            exit 1
+         fi
+      done
+   else
+      echo "$AGENT_TOOLSDIRECTORY/Ruby does not include any folders"
+      #exit 1 It's temporary mock until Ruby added to toolcache
+   fi
 else
    echo "$AGENT_TOOLSDIRECTORY/Ruby does not exist"
    # exit 1 It's temporary mock until Ruby added to toolcache

--- a/images/linux/scripts/installers/test-toolcache.sh
+++ b/images/linux/scripts/installers/test-toolcache.sh
@@ -63,9 +63,9 @@ if [ -d "$AGENT_TOOLSDIRECTORY/Ruby" ]; then
       done
    else
       echo "$AGENT_TOOLSDIRECTORY/Ruby does not include any folders"
-      #exit 1 It's temporary mock until Ruby added to toolcache
+      exit 1
    fi
 else
    echo "$AGENT_TOOLSDIRECTORY/Ruby does not exist"
-   # exit 1 It's temporary mock until Ruby added to toolcache
+   exit 1
 fi

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -145,7 +145,8 @@
                 "{{template_dir}}/scripts/installers/azpowershell.sh",
                 "{{template_dir}}/scripts/helpers/containercache.sh",
                 "{{template_dir}}/scripts/installers/hosted-tool-cache.sh",
-                "{{template_dir}}/scripts/installers/python.sh"
+                "{{template_dir}}/scripts/installers/python.sh",
+                "{{template_dir}}/scripts/installers/test-toolcache.sh"
             ],
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",

--- a/images/win/scripts/Installers/Validate-ToolCache.ps1
+++ b/images/win/scripts/Installers/Validate-ToolCache.ps1
@@ -27,36 +27,46 @@ function ToolcacheTest {
     if (Test-Path "$env:AGENT_TOOLSDIRECTORY\$SoftwareName")
     {
         $description = ""
-        $versions = GetChildFolders -Path "$env:AGENT_TOOLSDIRECTORY\$SoftwareName"
-        foreach ($version in $versions)
-        {
-            $architectures = GetChildFolders -Path "$env:AGENT_TOOLSDIRECTORY\$SoftwareName\$version"
-
-            Write-Host "$SoftwareName version - $version : $([system.String]::Join(",", $architectures))"
-
-            foreach ($arch in $architectures)
+        [array]$versions = GetChildFolders -Path "$env:AGENT_TOOLSDIRECTORY\$SoftwareName"
+        if ($versions.count -gt 0){
+            foreach ($version in $versions)
             {
-                $path = "$env:AGENT_TOOLSDIRECTORY\$SoftwareName\$version\$arch"
-                foreach ($test in $ExecTests)
-                {
-                    if (Test-Path "$path\$test")
-                    {
-                        Write-Host "$SoftwareName($test) $version($arch) is successfully installed:"
-                        Write-Host (& "$path\$test" --version)
-                    }
-                    else
-                    {
-                        Write-Host "$SoftwareName($test)  $version ($arch) is not installed"
-                        exit 1
-                    }
-                }
+                $architectures = GetChildFolders -Path "$env:AGENT_TOOLSDIRECTORY\$SoftwareName\$version"
 
-                $description += "_Version:_ $version ($arch)<br/>"
+                Write-Host "$SoftwareName version - $version : $([system.String]::Join(",", $architectures))"
+
+                foreach ($arch in $architectures)
+                {
+                    $path = "$env:AGENT_TOOLSDIRECTORY\$SoftwareName\$version\$arch"
+                    foreach ($test in $ExecTests)
+                    {
+                        if (Test-Path "$path\$test")
+                        {
+                            Write-Host "$SoftwareName($test) $version($arch) is successfully installed:"
+                            Write-Host (& "$path\$test" --version)
+                        }
+                        else
+                        {
+                            Write-Host "$SoftwareName($test)  $version ($arch) is not installed"
+                            exit 1
+                        }
+                    }
+
+                    $description += "_Version:_ $version ($arch)<br/>"
+                }
+            }
+
+            $description += $Note
+            Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $description
+        }
+        else
+        {
+            Write-Host "$env:AGENT_TOOLSDIRECTORY\$SoftwareName does not include any folders"
+            if ($IsRequireSoft)
+            {
+                exit 1
             }
         }
-
-        $description += $Note
-        Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $description
     }
     else
     {

--- a/images/win/scripts/Installers/Validate-ToolCache.ps1
+++ b/images/win/scripts/Installers/Validate-ToolCache.ps1
@@ -18,8 +18,6 @@ function ToolcacheTest {
         [Parameter(Mandatory = $True)]
         [string]$SoftwareName,
         [Parameter(Mandatory = $True)]
-        [bool]$IsRequireSoft,
-        [Parameter(Mandatory = $True)]
         [string[]]$ExecTests,
         [Parameter(Mandatory = $True)]
         [string]$Note
@@ -62,19 +60,13 @@ function ToolcacheTest {
         else
         {
             Write-Host "$env:AGENT_TOOLSDIRECTORY\$SoftwareName does not include any folders"
-            if ($IsRequireSoft)
-            {
-                exit 1
-            }
+            exit 1
         }
     }
     else
     {
         Write-Host "$env:AGENT_TOOLSDIRECTORY\$SoftwareName does not exist"
-        if ($IsRequireSoft)
-        {
-            exit 1
-        }
+        exit 1
     }
 }
 
@@ -84,7 +76,7 @@ $PythonNote += @"
 > Note: These versions of Python are available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task.
 "@
 $PythonTests = @("python.exe", "Scripts\pip.exe")
-ToolcacheTest -SoftwareName "Python" -IsRequireSoft $True -ExecTests $PythonTests -Note $PythonNote
+ToolcacheTest -SoftwareName "Python" -ExecTests $PythonTests -Note $PythonNote
 
 # Ruby test
 $RubyNote += @"
@@ -92,4 +84,4 @@ $RubyNote += @"
 > Note: These versions of Ruby are available through the [Use Ruby Version](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/use-ruby-version) task.
 "@
 $RubyTests = @("bin\ruby.exe")
-ToolcacheTest -SoftwareName "Ruby" -IsRequireSoft $False -ExecTests $RubyTests -Note $RubyNote
+ToolcacheTest -SoftwareName "Ruby" -ExecTests $RubyTests -Note $RubyNote

--- a/images/win/scripts/Installers/Validate-ToolCache.ps1
+++ b/images/win/scripts/Installers/Validate-ToolCache.ps1
@@ -10,7 +10,7 @@ function GetChildFolders {
         [Parameter(Mandatory = $True)]
         [string]$Path
     )
-    return Get-ChildItem "$Path" | Where-Object {$_.PSIsContainer} | Foreach-Object {$_.Name}
+    return Get-ChildItem -Path $Path -Directory -Name
 }
 
 function ToolcacheTest {

--- a/images/win/scripts/Installers/Validate-ToolCache.ps1
+++ b/images/win/scripts/Installers/Validate-ToolCache.ps1
@@ -4,63 +4,82 @@
 ##  Desc:  Validate Tool Cache
 ################################################################################
 
-# Python
-$pythonVersions = @(
-    ('2.7.14', 'x86'),
-    ('3.4.4', 'x86'),
-    ('3.5.4', 'x86'),
-    ('3.6.8', 'x86'),
-    ('3.7.2', 'x86')
-    ('2.7.14', 'x64'),
-    ('3.4.4', 'x64'),
-    ('3.5.4', 'x64'),
-    ('3.6.8', 'x64'),
-    ('3.7.2', 'x64')
-)
+# Helpers
+function GetChildFolders {
+    param (
+        [Parameter(Mandatory = $True)]
+        [string]$Path
+    )
+    return Get-ChildItem "$Path" | Where-Object {$_.PSIsContainer} | Foreach-Object {$_.Name}
+}
 
-foreach ($version in $pythonVersions)
-{
-    $v = $version[0]
-    $arch = $version[1]
-    $path = "$env:AGENT_TOOLSDIRECTORY\Python\$v\$arch"
-
-    if (Test-Path "$path\python.exe")
+function ToolcacheTest {
+    param (
+        [Parameter(Mandatory = $True)]
+        [string]$SoftwareName,
+        [Parameter(Mandatory = $True)]
+        [bool]$IsRequireSoft,
+        [Parameter(Mandatory = $True)]
+        [string[]]$ExecTests,
+        [Parameter(Mandatory = $True)]
+        [string]$Note
+    )
+    if (Test-Path "$env:AGENT_TOOLSDIRECTORY\$SoftwareName")
     {
-        Write-Host "Python $v ($arch) is successfully installed:"
-        Write-Host (& "$path\python.exe" --version)
+        $description = ""
+        $versions = GetChildFolders -Path "$env:AGENT_TOOLSDIRECTORY\$SoftwareName"
+        foreach ($version in $versions)
+        {
+            $architectures = GetChildFolders -Path "$env:AGENT_TOOLSDIRECTORY\$SoftwareName\$version"
+
+            Write-Host "$SoftwareName version - $version : $([system.String]::Join(",", $architectures))"
+
+            foreach ($arch in $architectures)
+            {
+                $path = "$env:AGENT_TOOLSDIRECTORY\$SoftwareName\$version\$arch"
+                foreach ($test in $ExecTests)
+                {
+                    if (Test-Path "$path\$test")
+                    {
+                        Write-Host "$SoftwareName($test) $version($arch) is successfully installed:"
+                        Write-Host (& "$path\$test" --version)
+                    }
+                    else
+                    {
+                        Write-Host "$SoftwareName($test)  $version ($arch) is not installed"
+                        exit 1
+                    }
+                }
+
+                $description += "_Version:_ $version ($arch)<br/>"
+            }
+        }
+
+        $description += $Note
+        Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $description
     }
     else
     {
-        Write-Host "Python $v ($arch) is not installed"
-        exit 1
-    }
-
-    if (Test-Path "$path\Scripts\pip.exe")
-    {
-        Write-Host "Pip for Python $v ($arch) is successfully installed:"
-        Write-Host (& "$path\Scripts\pip.exe" --version)
-    }
-    else
-    {
-        Write-Host "Pip for Python $v ($arch) is not installed"
-        exit 1
+        Write-Host "$env:AGENT_TOOLSDIRECTORY\$SoftwareName does not exist"
+        if ($IsRequireSoft)
+        {
+            exit 1
+        }
     }
 }
 
-# Adding description of the software to Markdown
-$SoftwareName = "Python"
-$Description = ""
-
-foreach ($version in $pythonVersions)
-{
-    $v = $version[0]
-    $arch = $version[1]
-    $Description += "_Version:_ $v ($arch)<br/>"
-}
-
-$Description += @"
+# Python test
+$PythonNote += @"
 <br/>
 > Note: These versions of Python are available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task.
 "@
+$PythonTests = @("python.exe", "Scripts\pip.exe")
+ToolcacheTest -SoftwareName "Python" -IsRequireSoft $True -ExecTests $PythonTests -Note $PythonNote
 
-Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description
+# Ruby test
+$RubyNote += @"
+<br/>
+> Note: These versions of Ruby are available through the [Use Ruby Version](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/use-ruby-version) task.
+"@
+$RubyTests = @("bin\ruby.exe")
+ToolcacheTest -SoftwareName "Ruby" -IsRequireSoft $False -ExecTests $RubyTests -Note $RubyNote


### PR DESCRIPTION
**Changes**:
- Added Python and Ruby built-in test for toolcache.
- Changed testing logic: Now validation logic doesn’t use predefined (hardcoded) list of versions. It iterates through all existing versions in tool-cache folder and check them. Also we have checked that list of versions is checked in build canary tests.