### PR TITLE
install vcredist140 latest

### DIFF
--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -131,6 +131,10 @@
         },
         {
             "type": "powershell",
+            "inline": ["choco install vcredist140 -y"]
+        },
+        {
+            "type": "powershell",
             "valid_exit_codes": [
                 0,
                 3010
@@ -270,7 +274,7 @@
                 "{{ template_dir }}/scripts/Installers/Install-Go.ps1"
             ]
         },
-         {
+        {
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-PHP.ps1"


### PR DESCRIPTION
because there are multiple dependencies on different versions down the chain. 

First [PHP](https://chocolatey.org/packages/php) installs `vcredist140 ≥ 14.11.25325.0` as a dependency. Later [openssl.light](https://chocolatey.org/packages/openssl.light) requires `vcredist140 ≥ 14.12.25810` and apparently `choco` doesn't install latest when a minimum required version is specified. The latter now fails because `vcredist140` doesn't support upgrade, apparently.

By installing `vcredist140` first both requirements for packages are satisfied.