### PR TITLE
macos 10.13 software updates week 16

### DIFF
--- a/images/macos/macos-10.13-Readme.md
+++ b/images/macos/macos-10.13-Readme.md
@@ -32,14 +32,14 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - Python 3.7.3
 - Ruby 2.6.2p47
 - .NET Core SDK 1.0.1, 1.0.4, 1.1.4, 1.1.5, 1.1.7, 1.1.8, 1.1.9, 1.1.10, 1.1.11, 1.1.12, 1.1.13, 2.0.0, 2.0.3, 2.1.100, 2.1.101, 2.1.102, 2.1.103, 2.1.104, 2.1.105, 2.1.503, 2.1.504, 2.1.505, 2.1.2, 2.1.200, 2.1.201, 2.1.300, 2.1.301, 2.1.4, 2.1.400, 2.1.401 2.1.402 2.1.502, 2.1.504, 2.2.101, 2.2.102, 2.2.103, 2.2.104, 2.2.105
-- Go 1.12.1
+- Go 1.12.3
 
 ### Package Management
 
 - Bundler 2.0.1
-- Carthage 0.32.0
+- Carthage 0.33.0
 - **CocoaPods 1.6.1** (Please, pay attention here. You may face an issue with pod install due to old dependencies in your pod file. In that case, you need to update your pod file with newer dependencies or rollback to CocoaPods 1.5.3 using this [post-clone script](https://github.com/Microsoft/appcenter-build-scripts-examples/tree/master/general/cocoapods-rollback))
-- Homebrew 2.0.6
+- Homebrew 2.1.0
 - NPM 3.10.10
 - Yarn 1.15.2
 - NuGet 4.7.0.5148
@@ -57,15 +57,15 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - curl 7.64.1 (libcurl/7.64.1 LibreSSL/2.0.20 zlib/1.2.11 nghttp2/1.24.0)
 - Git 2.21.0
 - Git LFS 2.7.1
-- GNU Wget 1.20.1
+- GNU Wget 1.20.3
 - Subversion (SVN) 1.11.1
 - GNU parallel 20190322
 
 ### Tools
 
-- fastlane 2.119.0
-- App Center CLI 1.1.14
-- Azure-CLI 2.0.61
+- fastlane 2.120.0
+- App Center CLI 1.1.15
+- Azure-CLI 2.0.62
 
 ### Pre-cached tools
 - Python 2.7.15 3.4.8 3.5.5 3.6.8 3.7.2
@@ -512,10 +512,11 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 ### Visual Studio for Mac
 
-- 7.8.3.2
+- 8.0.2.23
 
 ### Mono
 
+- 5.18.1
 - 5.16.1
 - 5.12.0
 - 5.10.1
@@ -529,6 +530,8 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 ### Xamarin.iOS SDK
 
+- 12.8.0.0
+- 12.6.0.25
 - 12.2.1.16
 - 12.2.1.11
 - 12.0.0.15
@@ -545,7 +548,8 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 ### Xamarin.Android SDK
 
-- 9.1.8.0
+- 9.2.0-5
+- 9.1.8-0
 - 9.0.0-20
 - 9.0.0-18
 - 8.3.3-2
@@ -559,6 +563,8 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 ### Xamarin.Mac SDK
 
+- 5.8.0.0
+- 5.6.0.25
 - 5.3.1.28
 - 5.2.1.16
 - 5.2.1.9


### PR DESCRIPTION
**Software Updates Week 16:**
- GNU Wget 1.20.3
- Homebrew 2.1.0
- App Center CLI 1.1.15
- fastlane 2.120.0
- Carthage 0.33.0
- azure-cli 2.0.62
- Go 1.12.3

**Xamarin:**
- Visual Studio for Mac: 8.0.2.23
- Mono Version: 5.18.1
- Xamarin.iOS SDK Version: 12.6.0.25
- Xamarin.iOS SDK Version: 12.8.0.0
- Xamarin.Android SDK Version: 9.2.0-5
- Xamarin.Mac SDK Version: 5.6.0.25
- Xamarin.Mac SDK Version: 5.8.0.0

Packages was pre-cached at 04/10