### PR TITLE
Go: major version shouldn't have patch number

### DIFF
--- a/images/linux/scripts/installers/go.sh
+++ b/images/linux/scripts/installers/go.sh
@@ -33,4 +33,4 @@ function InstallGo () {
 InstallGo 1.9 1.9.7 false
 InstallGo 1.10 1.10.8 false
 InstallGo 1.11 1.11.6 false
-InstallGo 1.12.1 1.12.1 true
+InstallGo 1.12 1.12.1 true


### PR DESCRIPTION
This makes it possible to specify something like `GOROOT: '/usr/local/go1.12` for Go 1.12.

It now behaves similarly to how 1.11, 1.10 and 1.9 do.