### PR TITLE
Update Install-Ruby.ps1 and Validate-Ruby.ps1 scripts

### DIFF
--- a/images/win/scripts/Installers/Install-Ruby.ps1
+++ b/images/win/scripts/Installers/Install-Ruby.ps1
@@ -8,7 +8,14 @@ Import-Module -Name ImageHelpers
 
 # Ruby versions are already available in the tool cache.
 
-# Add the latest available version of Ruby to the path.
-Add-MachinePathItem "C:\hostedtoolcache\windows\Ruby\2.5.0\x64\bin"
+# Tool cache Ruby Path
+$toolcacheRubyPath = 'C:\hostedtoolcache\windows\Ruby\2.5.*'
+
+# Get Latest Ruby 2.5.x
+$latestRubyBinPath2_5 = Get-ChildItem -Path $toolcacheRubyPath | Sort-Object {[System.Version]$_.Name} | Select-Object -Last 1 | ForEach-Object {
+	Join-Path $_.FullName 'x64\bin'
+}
+
+Add-MachinePathItem $latestRubyBinPath2_5
 $env:Path = Get-MachinePath
 exit 0

--- a/images/win/scripts/Installers/Validate-Ruby.ps1
+++ b/images/win/scripts/Installers/Validate-Ruby.ps1
@@ -47,7 +47,7 @@ $SoftwareName = "Ruby (x64)"
 $Description = @"
 #### $rubyVersionOnPath
 _Environment:_
-* Location:$rubyBinOnPath
+* Location: $rubyBinOnPath
 * PATH: contains the location of ruby.exe version $rubyVersionOnPath
 "@
 

--- a/images/win/scripts/Installers/Validate-Ruby.ps1
+++ b/images/win/scripts/Installers/Validate-Ruby.ps1
@@ -37,29 +37,18 @@ else
     exit 1
 }
 
-# Get available versions of Ruby
-# Tool cache Ruby Path
-$toolcacheRubyPath = 'C:\hostedtoolcache\windows\Ruby'
-
 # Default Ruby Version on Path
-$rubyVersionOnPath = (Get-Command -Name 'ruby').Path
-
-# Markdown Output
-$rubyVersionOutput = Get-ChildItem -Path $toolcacheRubyPath -Directory | Foreach-Object {
-	$rubyBinPath = Join-Path $_.FullName 'x64\bin'
-	$rubyVersion = Get-RubyVersion -rubyRootPath $rubyBinPath
-
-	if ($rubyVersionOnPath.Contains($rubyBinPath)) {
-		"#### {0} `r`n_Environment:_ `r`n* Location: {1} `r`n* PATH: contains the location of ruby.exe version {0}" -f $rubyVersion, $rubyBinPath
-	} else {
-		"#### {0} `r`n_Location:_ {1}" -f $rubyVersion, $rubyBinPath
-	}
-} | Out-String
+$rubyExeOnPath = (Get-Command -Name 'ruby').Path
+$rubyBinOnPath = Split-Path -Path $rubyExeOnPath
+$rubyVersionOnPath = Get-RubyVersion -rubyRootPath $rubyBinPath
 
 # Add details of available versions in Markdown
 $SoftwareName = "Ruby (x64)"
 $Description = @"
-{0}
-"@ -f $rubyVersionOutput
+#### $rubyVersionOnPath
+_Environment:_
+* Location:$rubyBinOnPath
+* PATH: contains the location of ruby.exe version $rubyVersionOnPath
+"@
 
 Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description

--- a/images/win/scripts/Installers/Validate-Ruby.ps1
+++ b/images/win/scripts/Installers/Validate-Ruby.ps1
@@ -13,7 +13,7 @@ function Get-RubyVersion
     )
 
     # Prepend to the path like: C:\hostedtoolcache\windows\Ruby\2.5.0\x64\bin
-    $env:Path = "$rubyRootPath\x64\bin;" + $env:Path
+    $env:Path = "$rubyRootPath;" + $env:Path
 
     # Extract the version from Ruby output like: ruby 2.5.1p57 (2018-03-29 revision 63029) [x64-mingw32]
     if( $(ruby --version) -match 'ruby (?<version>.*) \(.*' )
@@ -38,21 +38,28 @@ else
 }
 
 # Get available versions of Ruby
-$rubyVersion2_4 = Get-RubyVersion -rubyRootPath "C:\hostedtoolcache\windows\Ruby\2.4.3"
-$rubyVersionOnPath = Get-RubyVersion -rubyRootPath "C:\hostedtoolcache\windows\Ruby\2.5.0"
+# Tool cache Ruby Path
+$toolcacheRubyPath = 'C:\hostedtoolcache\windows\Ruby'
+
+# Default Ruby Version on Path
+$rubyVersionOnPath = (Get-Command -Name 'ruby').Path
+
+# Markdown Output
+$rubyVersionOutput = Get-ChildItem -Path $toolcacheRubyPath -Directory | Foreach-Object {
+	$rubyBinPath = Join-Path $_.FullName 'x64\bin'
+	$rubyVersion = Get-RubyVersion -rubyRootPath $rubyBinPath
+
+	if ($rubyVersionOnPath.Contains($rubyBinPath)) {
+		"#### {0} `r`n_Environment:_ `r`n* Location: {1} `r`n* PATH: contains the location of ruby.exe version {0}" -f $rubyVersion, $rubyBinPath
+	} else {
+		"#### {0} `r`n_Location:_ {1}" -f $rubyVersion, $rubyBinPath
+	}
+} | Out-String
 
 # Add details of available versions in Markdown
 $SoftwareName = "Ruby (x64)"
 $Description = @"
-#### $rubyVersion2_4
-
-_Location:_ C:\hostedtoolcache\windows\Ruby\2.4.3\x64\bin
-
-#### $rubyVersionOnPath
-
-_Environment:_
-* Location: C:\hostedtoolcache\windows\Ruby\2.5.0\x64\bin
-* PATH: contains the location of ruby.exe version $rubyVersionOnPath
-"@
+{0}
+"@ -f $rubyVersionOutput
 
 Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description


### PR DESCRIPTION
Issue:
Old hard-coded Ruby 2.5.0 was deleted from the tool cache that cause an error in the Validate-Ruby.ps1 

Fix:
Update Install-Ruby.ps1 and Validate-Ruby.ps1 to use the  latest Ruby 2.5.x version from the tool cache.