### PR TITLE
Add Dotfuscator to Visual Studio 2019

### DIFF
--- a/images/win/Vs2019-Server2019-Readme.md
+++ b/images/win/Vs2019-Server2019-Readme.md
@@ -45,7 +45,6 @@ _Location:_ C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
 The following workloads and components are installed with Visual Studio 2019:
 * Component.CPython2.x64
 * Component.Linux.CMake
-* Component.Dotfuscator
 * Component.UnityEngine.x64
 * Component.UnityEngine.x86
 * Component.Unreal.Android
@@ -332,7 +331,7 @@ _Version:_ 2.7.14 (x86)<br/>_Version:_ 3.4.4 (x86)<br/>_Version:_ 3.5.4 (x86)<br
 
 ## Python (64 bit)
 
-####
+#### 
 _Environment:_
 * PATH: contains location of python.exe
 
@@ -370,9 +369,9 @@ _Environment:_
 
 ## Boost
 
-####
+#### 
 
-* PATH: contains the location of Boost version
+* PATH: contains the location of Boost version 
 * BOOST_ROOT: root directory of the Boost version  installation
 * BOOST_ROOT_1_69_0: root directory of the Boost version  installation
 

--- a/images/win/Vs2019-Server2019-Readme.md
+++ b/images/win/Vs2019-Server2019-Readme.md
@@ -45,6 +45,7 @@ _Location:_ C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
 The following workloads and components are installed with Visual Studio 2019:
 * Component.CPython2.x64
 * Component.Linux.CMake
+* Component.Dotfuscator
 * Component.UnityEngine.x64
 * Component.UnityEngine.x86
 * Component.Unreal.Android
@@ -331,7 +332,7 @@ _Version:_ 2.7.14 (x86)<br/>_Version:_ 3.4.4 (x86)<br/>_Version:_ 3.5.4 (x86)<br
 
 ## Python (64 bit)
 
-#### 
+####
 _Environment:_
 * PATH: contains location of python.exe
 
@@ -369,9 +370,9 @@ _Environment:_
 
 ## Boost
 
-#### 
+####
 
-* PATH: contains the location of Boost version 
+* PATH: contains the location of Boost version
 * BOOST_ROOT: root directory of the Boost version  installation
 * BOOST_ROOT_1_69_0: root directory of the Boost version  installation
 

--- a/images/win/scripts/Installers/Vs2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Vs2019/Install-VS2019.ps1
@@ -63,6 +63,7 @@ Function InstallVS
 
 $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Component.CPython2.x64 ' + `
+              '--add Component.Dotfuscator' + `
               '--add Component.Linux.CMake ' + `
               '--add Component.UnityEngine.x64 ' + `
               '--add Component.UnityEngine.x86 ' + `


### PR DESCRIPTION
This Pull request will add Dotfuscator Community as a component installed in Visual Studio 2019 on `windows-2019` agents. Both of the other agents (`vs2015-win2012r2` and `vs2017-win2016`) come with Dotfuscator already installed, but in the process of updating the Dotfuscator Community build task we noticed it was not installed on the 2019 agents.

We would like to add Dotfuscator to the 2019 image so that users can protect their application in the latest version of Visual Studio using the Dotfuscator Community build task.

The Dotfuscator Build Task can be found on the Visual Studio Marketplace: https://marketplace.visualstudio.com/items?itemName=PreEmptiveSolutions.dotfuscator-ce-vsts