### PR TITLE
Allowing capture_name_prefix to be sent to packer template 

### DIFF
--- a/images/linux/linux_preview.json
+++ b/images/linux/linux_preview.json
@@ -27,7 +27,7 @@
             "resource_group_name": "{{user `resource_group`}}",
             "storage_account": "{{user `storage_account`}}",
             "capture_container_name": "images",
-            "capture_name_prefix": "packer",
+            "capture_name_prefix": "{{user `capture_name_prefix`}}",
             "os_type": "Linux",
             "image_publisher": "Canonical",
             "image_offer": "UbuntuServer",

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -28,7 +28,7 @@
             "resource_group_name": "{{user `resource_group`}}",
             "storage_account": "{{user `storage_account`}}",
             "capture_container_name": "images",
-            "capture_name_prefix": "packer",
+            "capture_name_prefix": "{{user `capture_name_prefix`}}",
             "os_type": "Linux",
             "image_publisher": "Canonical",
             "image_offer": "UbuntuServer",

--- a/images/win/WindowsContainer1803-Azure.json
+++ b/images/win/WindowsContainer1803-Azure.json
@@ -34,7 +34,7 @@
             "resource_group_name": "{{user `resource_group`}}",
             "storage_account": "{{user `storage_account`}}",
             "capture_container_name": "images",
-            "capture_name_prefix": "packer",
+            "capture_name_prefix": "{{user `capture_name_prefix`}}",
             "os_type": "Windows",
             "image_publisher": "MicrosoftWindowsServer",
             "image_offer": "WindowsServerSemiAnnual",

--- a/images/win/vs2015-Server2012R2-Azure.json
+++ b/images/win/vs2015-Server2012R2-Azure.json
@@ -34,7 +34,7 @@
             "resource_group_name": "{{user `resource_group`}}",
             "storage_account": "{{user `storage_account`}}",
             "capture_container_name": "images",
-            "capture_name_prefix": "packer",
+            "capture_name_prefix": "{{user `capture_name_prefix`}}",
             "os_type": "Windows",
             "image_publisher": "MicrosoftWindowsServer",
             "image_offer": "WindowsServer",

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -34,7 +34,7 @@
             "resource_group_name": "{{user `resource_group`}}",
             "storage_account": "{{user `storage_account`}}",
             "capture_container_name": "images",
-            "capture_name_prefix": "packer",
+            "capture_name_prefix": "{{user `capture_name_prefix`}}",
             "os_type": "Windows",
             "image_publisher": "MicrosoftWindowsServer",
             "image_offer": "WindowsServer",

--- a/images/win/vs2019-Server2019-Azure.json
+++ b/images/win/vs2019-Server2019-Azure.json
@@ -35,7 +35,7 @@
             "resource_group_name": "{{user `resource_group`}}",
             "storage_account": "{{user `storage_account`}}",
             "capture_container_name": "images",
-            "capture_name_prefix": "packer",
+            "capture_name_prefix": "{{user `capture_name_prefix`}}",
             "os_type": "Windows",
             "image_publisher": "MicrosoftWindowsServer",
             "image_offer": "WindowsServer",


### PR DESCRIPTION
This allows us to better discover the generated images in the storage account. This is necessary for the automated image pipeline since it allows us to pick up the generated image exactly and continue deploying it.