### PR TITLE
macos 10.14 software updates week 18

### DIFF
--- a/images/macos/macos-10.14-Readme.md
+++ b/images/macos/macos-10.14-Readme.md
@@ -25,7 +25,7 @@ We will be switching to use [Azul OpenJDKs](https://azure.microsoft.com/en-us/bl
 - PowerShell 6.2.0
 - Python 2.7.16
 - Python 3.7.3
-- Ruby 2.6.2p47
+- Ruby 2.6.3p62
 - .NET Core SDK 1.0.1 1.0.4 1.1.10 1.1.11 1.1.12 1.1.13 1.1.4 1.1.5 1.1.7 1.1.8 1.1.9 2.0.0 2.0.3 2.1.100 2.1.101 2.1.102 2.1.103 2.1.104 2.1.105 2.1.2 2.1.200 2.1.201 2.1.202 2.1.300 2.1.301 2.1.302 2.1.4 2.1.400 2.1.401 2.1.402 2.1.403 2.1.500 2.1.502 2.1.503 2.1.504 2.1.505 2.2.100 2.2.101 2.2.102 2.2.103 2.2.104 2.2.105
 - Go 1.12.3
 
@@ -39,7 +39,7 @@ We will be switching to use [Azul OpenJDKs](https://azure.microsoft.com/en-us/bl
 - Yarn 1.15.2
 - NuGet 4.7.0.5148
 - pip 19.0.3
-- Miniconda 4.5.12
+- Miniconda 4.6.14
 
 ### Project Management
 
@@ -50,15 +50,15 @@ We will be switching to use [Azul OpenJDKs](https://azure.microsoft.com/en-us/bl
 
 - curl 7.64.1 (libcurl/7.64.1 SecureTransport zlib/1.2.11)
 - Git 2.21.0
-- Git LFS 2.7.1
+- Git LFS 2.7.2
 - GNU Wget 1.20.3
 - Subversion (SVN) 1.11.1
 
 ### Tools
 
-- fastlane 2.120.0
+- fastlane 2.121.1
 - App Center CLI 1.1.15
-- Azure-CLI 2.0.62
+- Azure-CLI 2.0.63
 
 ### Pre-cached tools
 - Python 2.7.15 3.4.8 3.5.5 3.6.8 3.7.2
@@ -480,7 +480,7 @@ We will be switching to use [Azul OpenJDKs](https://azure.microsoft.com/en-us/bl
 
 ### Visual Studio for Mac
 
-- 8.0.2.23
+- 8.0.4.0
 
 ### Mono
 
@@ -515,7 +515,7 @@ We will be switching to use [Azul OpenJDKs](https://azure.microsoft.com/en-us/bl
 
 ### Xamarin.Android SDK
 
-- 9.2.0-5
+- 9.2.3-0
 - 9.1.8-0
 - 9.0.0-20
 - 9.0.0-18


### PR DESCRIPTION
Software updates:
   ruby 2.6.3p62
   Git LFS 2.7.2
   fastlane 2.121.1
   azure-cli 2.0.63
   Miniconda 4.6.14

Xamarin:
   Visual Studio for Mac: 8.0.4.0
   Xamarin.Android SDK Version: 9.2.3-0

