### PR TITLE
Add PyPy to the macOS READMEs

### DIFF
--- a/images/macos/macos-10.13-Readme.md
+++ b/images/macos/macos-10.13-Readme.md
@@ -68,8 +68,19 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - Azure-CLI 2.0.63
 
 ### Pre-cached tools
-- Python 2.7.16 3.4.8 3.5.7 3.6.8 3.7.3
-- Ruby 2.3.8 2.4.6 2.5.5 2.6.2
+- Python (available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task)
+  - 2.7.16
+  - 3.4.8
+  - 3.5.7
+  - 3.6.8
+  - 3.7.3
+  - pypy2
+  - pypy3
+- Ruby (available through the [Use Ruby Version](https://go.microsoft.com/fwlink/?linkid=2005989) task)
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2
 
 ### Xcode
 | Version                | Build   | Path                          |

--- a/images/macos/macos-10.14-Readme.md
+++ b/images/macos/macos-10.14-Readme.md
@@ -65,8 +65,19 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
 - Azure-CLI 2.0.63
 
 ### Pre-cached tools
-- Python 2.7.16 3.4.8 3.5.7 3.6.8 3.7.3
-- Ruby 2.3.8 2.4.6 2.5.5 2.6.2
+- Python (available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task)
+  - 2.7.16
+  - 3.4.8
+  - 3.5.7
+  - 3.6.8
+  - 3.7.3
+  - pypy2
+  - pypy3
+- Ruby (available through the [Use Ruby Version](https://go.microsoft.com/fwlink/?linkid=2005989) task)
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2
 
 ### Xcode
 | Version                | Build   | Path                            |


### PR DESCRIPTION
PyPy was added to the tools cache for Hosted macOS in S150.  I tested to make sure it is now available on both the High Sierra and Mojave pools.

I also tweaked the Python and Ruby version lists to match the VS2017 and Ubuntu READMEs.