### PR TITLE
Cherry pick Ruby fixes into VS2019 release branch

### DIFF
--- a/images/win/scripts/Installers/Install-Ruby.ps1
+++ b/images/win/scripts/Installers/Install-Ruby.ps1
@@ -8,7 +8,14 @@ Import-Module -Name ImageHelpers
 
 # Ruby versions are already available in the tool cache.
 
-# Add the latest available version of Ruby to the path.
-Add-MachinePathItem "C:\hostedtoolcache\windows\Ruby\2.5.0\x64\bin"
+# Tool cache Ruby Path
+$toolcacheRubyPath = 'C:\hostedtoolcache\windows\Ruby\2.5.*'
+
+# Get Latest Ruby 2.5.x
+$latestRubyBinPath2_5 = Get-ChildItem -Path $toolcacheRubyPath | Sort-Object {[System.Version]$_.Name} | Select-Object -Last 1 | ForEach-Object {
+	Join-Path $_.FullName 'x64\bin'
+}
+
+Add-MachinePathItem $latestRubyBinPath2_5
 $env:Path = Get-MachinePath
 exit 0

--- a/images/win/scripts/Installers/Validate-Ruby.ps1
+++ b/images/win/scripts/Installers/Validate-Ruby.ps1
@@ -13,7 +13,7 @@ function Get-RubyVersion
     )
 
     # Prepend to the path like: C:\hostedtoolcache\windows\Ruby\2.5.0\x64\bin
-    $env:Path = "$rubyRootPath\x64\bin;" + $env:Path
+    $env:Path = "$rubyRootPath;" + $env:Path
 
     # Extract the version from Ruby output like: ruby 2.5.1p57 (2018-03-29 revision 63029) [x64-mingw32]
     if( $(ruby --version) -match 'ruby (?<version>.*) \(.*' )
@@ -37,21 +37,17 @@ else
     exit 1
 }
 
-# Get available versions of Ruby
-$rubyVersion2_4 = Get-RubyVersion -rubyRootPath "C:\hostedtoolcache\windows\Ruby\2.4.3"
-$rubyVersionOnPath = Get-RubyVersion -rubyRootPath "C:\hostedtoolcache\windows\Ruby\2.5.0"
+# Default Ruby Version on Path
+$rubyExeOnPath = (Get-Command -Name 'ruby').Path
+$rubyBinOnPath = Split-Path -Path $rubyExeOnPath
+$rubyVersionOnPath = Get-RubyVersion -rubyRootPath $rubyBinPath
 
 # Add details of available versions in Markdown
 $SoftwareName = "Ruby (x64)"
 $Description = @"
-#### $rubyVersion2_4
-
-_Location:_ C:\hostedtoolcache\windows\Ruby\2.4.3\x64\bin
-
 #### $rubyVersionOnPath
-
 _Environment:_
-* Location: C:\hostedtoolcache\windows\Ruby\2.5.0\x64\bin
+* Location: $rubyBinOnPath
 * PATH: contains the location of ruby.exe version $rubyVersionOnPath
 "@
 

--- a/images/win/scripts/Installers/Validate-Ruby.ps1
+++ b/images/win/scripts/Installers/Validate-Ruby.ps1
@@ -40,7 +40,7 @@ else
 # Default Ruby Version on Path
 $rubyExeOnPath = (Get-Command -Name 'ruby').Path
 $rubyBinOnPath = Split-Path -Path $rubyExeOnPath
-$rubyVersionOnPath = Get-RubyVersion -rubyRootPath $rubyBinPath
+$rubyVersionOnPath = Get-RubyVersion -rubyRootPath $rubyBinOnPath
 
 # Add details of available versions in Markdown
 $SoftwareName = "Ruby (x64)"


### PR DESCRIPTION
Hosted tool cache now contains Ruby 2.4.5 and 2.5.3, update paths in validation.

This fix was already put in master but releases/VS2019/151.1 was branched out before it went in.