### PR TITLE
Add the ability to specify capture_name_prefix for all packer configs.

### DIFF
--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -13,7 +13,8 @@
         "metadata_file": "/imagegeneration/metadatafile",
         "installer_script_folder": "/imagegeneration/installers",
         "helper_script_folder": "/imagegeneration/helpers",
-        "vm_size": "Standard_DS2_v2"
+        "vm_size": "Standard_DS2_v2",
+        "capture_name_prefix": "packer"
     },
     "builders": [
         {
@@ -28,7 +29,7 @@
             "resource_group_name": "{{user `resource_group`}}",
             "storage_account": "{{user `storage_account`}}",
             "capture_container_name": "images",
-            "capture_name_prefix": "packer",
+            "capture_name_prefix": "{{user `capture_name_prefix`}}",
             "os_type": "Linux",
             "image_publisher": "Canonical",
             "image_offer": "UbuntuServer",

--- a/images/win/WindowsContainer1803-Azure.json
+++ b/images/win/WindowsContainer1803-Azure.json
@@ -17,7 +17,8 @@
         "helper_script_folder": "C:\\Program Files\\WindowsPowerShell\\Modules\\",
         "commit_id": "LATEST",
         "install_user": "installer",
-        "install_password": null
+        "install_password": null,
+        "capture_name_prefix": "packer"
     },
     "builders": [
         {
@@ -34,7 +35,7 @@
             "resource_group_name": "{{user `resource_group`}}",
             "storage_account": "{{user `storage_account`}}",
             "capture_container_name": "images",
-            "capture_name_prefix": "packer",
+            "capture_name_prefix": "{{user `capture_name_prefix`}}",
             "os_type": "Windows",
             "image_publisher": "MicrosoftWindowsServer",
             "image_offer": "WindowsServerSemiAnnual",

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -17,7 +17,8 @@
         "helper_script_folder": "C:\\Program Files\\WindowsPowerShell\\Modules\\",
         "commit_id": "LATEST",
         "install_user": "installer",
-        "install_password": null
+        "install_password": null,
+        "capture_name_prefix": "packer"
     },
     "builders": [
         {
@@ -34,7 +35,7 @@
             "resource_group_name": "{{user `resource_group`}}",
             "storage_account": "{{user `storage_account`}}",
             "capture_container_name": "images",
-            "capture_name_prefix": "packer",
+            "capture_name_prefix": "{{user `capture_name_prefix`}}",
             "os_type": "Windows",
             "image_publisher": "MicrosoftWindowsServer",
             "image_offer": "WindowsServer",

--- a/images/win/vs2019-Server2019-Azure.json
+++ b/images/win/vs2019-Server2019-Azure.json
@@ -17,7 +17,8 @@
         "helper_script_folder": "C:\\Program Files\\WindowsPowerShell\\Modules\\",
         "commit_id": "LATEST",
         "install_user": "installer",
-        "install_password": null
+        "install_password": null,
+        "capture_name_prefix": "packer"
     },
     "sensitive-variables": ["install_password", "ssh_password", "client_secret"],
     "builders": [
@@ -35,7 +36,7 @@
             "resource_group_name": "{{user `resource_group`}}",
             "storage_account": "{{user `storage_account`}}",
             "capture_container_name": "images",
-            "capture_name_prefix": "packer",
+            "capture_name_prefix": "{{user `capture_name_prefix`}}",
             "os_type": "Windows",
             "image_publisher": "MicrosoftWindowsServer",
             "image_offer": "WindowsServer",


### PR DESCRIPTION
Keep the default of "packer" for the prefix of the name of the resources that gets generated but allow specifying a different prefix at runtime. This is useful to differentiate between images being generated in parallel.