### PR TITLE
update docker pull for windows server core

### DIFF
--- a/images/win/scripts/Installers/Vs2019/Update-DockerImages.ps1
+++ b/images/win/scripts/Installers/Vs2019/Update-DockerImages.ps1
@@ -19,7 +19,7 @@ function DockerPull {
     $results
 }
 
-DockerPull microsoft/windowsservercore
+DockerPull microsoft/windowsservercore:ltsc2019
 DockerPull microsoft/nanoserver
 DockerPull microsoft/aspnetcore-build:1.0-2.0
 DockerPull microsoft/aspnet


### PR DESCRIPTION
When calling `docker pull microsoft/windowsservercore` docker will attempt to pull the `latest` tag. This tag does not exist against that dockerhub repo. Instead it should pull `ltsc2019`.