### PR TITLE
microsoft/nanoserver Docker image needs a tag

### DIFF
--- a/images/win/scripts/Installers/Vs2019/Update-DockerImages.ps1
+++ b/images/win/scripts/Installers/Vs2019/Update-DockerImages.ps1
@@ -20,7 +20,7 @@ function DockerPull {
 }
 
 DockerPull microsoft/windowsservercore:ltsc2019
-DockerPull microsoft/nanoserver
+DockerPull microsoft/nanoserver:1809
 DockerPull microsoft/aspnetcore-build:1.0-2.0
 DockerPull microsoft/aspnet
 DockerPull microsoft/dotnet-framework


### PR DESCRIPTION
Follow-up to #924.

[microsoft/nanoserver](https://hub.docker.com/_/microsoft-windows-nanoserver) also does not publish :latest and needs to be specified.