### PR TITLE
Add 1809 label to missing windowsservercore and nanoserver container (VS2019)

### DIFF
--- a/images/win/scripts/Installers/Vs2017/Update-DockerImages.ps1
+++ b/images/win/scripts/Installers/Vs2017/Update-DockerImages.ps1
@@ -19,8 +19,8 @@ function DockerPull {
     $results
 }
 
-DockerPull microsoft/windowsservercore
-DockerPull microsoft/nanoserver
+DockerPull microsoft/windowsservercore:1809
+DockerPull microsoft/nanoserver:1809
 DockerPull microsoft/aspnetcore-build:1.0-2.0
 DockerPull microsoft/aspnet
 DockerPull microsoft/dotnet-framework

--- a/images/win/scripts/Installers/Vs2019/Update-DockerImages.ps1
+++ b/images/win/scripts/Installers/Vs2019/Update-DockerImages.ps1
@@ -19,8 +19,8 @@ function DockerPull {
     $results
 }
 
-DockerPull microsoft/windowsservercore
-DockerPull microsoft/nanoserver
+DockerPull microsoft/windowsservercore:1809
+DockerPull microsoft/nanoserver:1809
 DockerPull microsoft/aspnetcore-build:1.0-2.0
 DockerPull microsoft/aspnet
 DockerPull microsoft/dotnet-framework


### PR DESCRIPTION
Add 1809 label to missing windowsservercore and nanoserver container images for both VS2017 and VS2019.