### PR TITLE
Fix display of container items and merge latest Ubuntu readme file.

### DIFF
--- a/images/linux/Ubuntu1604-README.md
+++ b/images/linux/Ubuntu1604-README.md
@@ -2,13 +2,11 @@
 The following software is installed on machines in the Hosted Ubuntu 1604 pool
 ***
 - 7-Zip 9.20
-- Ansible (ansible 2.0.0.2)
+- Ansible (ansible 2.7.10)
 - AzCopy (azcopy 7.3.0-netcore)
-- Az Module (available through the [Azure PowerShell](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/deploy/azure-powershell?view=azure-devops) task)
-  - Az 1.0.0
-- Azure CLI (azure-cli                         2.0.61)
-- Azure CLI (azure-devops                       0.4.0)
-- Basic CLI:
+- Azure CLI (azure-cli                         2.0.64)
+- Azure CLI (azure-devops                       0.8.0)
+- Basic CLI: 
   - curl
   - dnsutils
   - file
@@ -35,7 +33,7 @@ The following software is installed on machines in the Hosted Ubuntu 1604 pool
 - Clang 6.0 (clang version 6.0.1-svn334776-1~exp1~20190309042730.123 (branches/release_60))
 - CMake (cmake version 3.12.4)
 - Docker Compose (docker-compose version 1.22.0, build f46880fe)
-- Docker (Docker version 3.0.3, build 48bd4c6d)
+- Docker (Docker version 3.0.5, build ba9934d4)
 - .NET Core SDK 1.0.1
 - .NET Core SDK 1.0.4
 - .NET Core SDK 1.1.10
@@ -78,56 +76,64 @@ The following software is installed on machines in the Hosted Ubuntu 1604 pool
 - .NET Core SDK 2.2.103
 - .NET Core SDK 2.2.104
 - .NET Core SDK 2.2.105
-- Erlang (Erlang (SMP,ASYNC_THREADS,HIPE) (BEAM) emulator version 10.3.2)
-- Firefox (Mozilla Firefox 66.0.2)
+- Erlang (Erlang (SMP,ASYNC_THREADS,HIPE) (BEAM) emulator version 10.3.4)
+- Firefox (Mozilla Firefox 66.0.4)
 - GNU C++ 7.4.0
 - Git (2.21.0)
-- Git Large File Storage (LFS) (2.7.1)
+- Git Large File Storage (LFS) (2.7.2)
 - Go 1.9 (go version go1.9.7 linux/amd64)
 - Go 1.10 (go version go1.10.8 linux/amd64)
-- Go 1.11 (go version go1.11.6 linux/amd64)
-- Go 1.12.1 (go version go1.12.1 linux/amd64)
-- Google Chrome (Google Chrome 73.0.3683.86 )
+- Go 1.11 (go version go1.11.9 linux/amd64)
+- Go 1.12 (go version go1.12.4 linux/amd64)
+- Google Chrome (Google Chrome 74.0.3729.131 )
 - Haskell (The Glorious Glasgow Haskell Compilation System, version 7.10.3)
-- Heroku (heroku/7.22.7 linux-x64 node-v11.10.1)
-- HHVM (HipHop VM 4.0.3 (rel))
+- Heroku (heroku/7.24.3 linux-x64 node-v11.14.0)
+- HHVM (HipHop VM 4.4.0 (rel))
 - ImageMagick
-- Azul Zulu OpenJDK (7) (openjdk version "1.7.0_211")
-- Azul Zulu OpenJDK (8) (openjdk version "1.8.0_202")
-- Azul Zulu OpenJDK (11) (openjdk version "11.0.2" 2019-01-15 LTS)
-- Azul Zulu OpenJDK (12) (openjdk version "12" 2019-03-19)
+- Azul Zulu OpenJDK (7) (openjdk version "1.7.0_222")
+- Azul Zulu OpenJDK (8) (openjdk version "1.8.0_212")
+- Azul Zulu OpenJDK (11) (openjdk version "11.0.3" 2019-04-16 LTS)
+- Azul Zulu OpenJDK (12) (openjdk version "12.0.1" 2019-04-16)
 - Ant (Apache Ant(TM) version 1.9.6 compiled on July 20 2018)
-- Gradle 5.3.1
-- Maven (Apache Maven 3.6.0 (97c98ec64a1fdfee7767ce5ffb20918da4f719f3; 2018-10-24T18:41:47Z))
-- kubectl (Client Version: v1.14.0)
+- Gradle 
+- Maven (Apache Maven 3.6.1 (d66c9c0b3152b2e69ee9bac180bb8fcc8e6af555; 2019-04-04T19:00:29Z))
+- kubectl (Client Version: v1.14.1)
 - helm (Client: v2.11.0+g2e55dbe)
-- Leiningen (Leiningen 2.9.1 on Java 1.8.0_202 OpenJDK 64-Bit Server VM)
+- Leiningen (Leiningen 2.9.1 on Java 1.8.0_212 OpenJDK 64-Bit Server VM)
 - Mercurial (Mercurial Distributed SCM (version 4.4.1))
-- Miniconda (conda 4.5.12)
-- Mono (Mono JIT compiler version 5.18.1.0 (tarball Fri Mar 15 20:45:47 UTC 2019))
-- MySQL (mysql  Ver 14.14 Distrib 5.7.25, for Linux (x86_64) using  EditLine wrapper)
+- Miniconda (conda 4.6.14)
+- Mono (Mono JIT compiler version 5.20.1.19 (tarball Thu Apr 11 09:09:21 UTC 2019))
+- MySQL (mysql  Ver 14.14 Distrib 5.7.26, for Linux (x86_64) using  EditLine wrapper)
 - MySQL Server (user:root password:root)
 - MS SQL Server Client Tools
 - Node.js (v10.15.3)
 - Bower (1.8.8)
 - Grunt (grunt-cli v1.2.0)
-- Gulp (CLI version 2.1.0)
-- n (3.0.0)
+- Gulp (CLI version: 2.2.0)
+- n (4.0.0)
 - Parcel (1.12.3)
-- TypeScript (Version 3.4.1)
-- Webpack (4.29.6)
-- Webpack CLI (3.3.0)
+- TypeScript (Version 3.4.5)
+- Webpack (4.30.0)
+- Webpack CLI (3.3.2)
 - Yarn (1.15.2)
 - PhantomJS (2.1.1)
-- PHP 5.6 (PHP 5.6.40-5+ubuntu16.04.1+deb.sury.org+1 (cli) )
-- PHP 7.0 (PHP 7.0.33-5+ubuntu16.04.1+deb.sury.org+1 (cli) (built: Mar  8 2019 09:48:51) ( NTS ))
-- PHP 7.1 (PHP 7.1.27-1+ubuntu16.04.1+deb.sury.org+1 (cli) (built: Mar  7 2019 20:02:03) ( NTS ))
-- PHP 7.2 (PHP 7.2.16-1+ubuntu16.04.1+deb.sury.org+1 (cli) (built: Mar  7 2019 20:23:06) ( NTS ))
-- PHP 7.3 (PHP 7.3.3-1+ubuntu16.04.1+deb.sury.org+1 (cli) (built: Mar  7 2019 20:31:26) ( NTS ))
-- Composer  (Composer version 1.8.4 2019-02-11 10:52:10)
-- PHPUnit (PHPUnit 7.5.8 by Sebastian Bergmann and contributors.)
+- PHP 5.6 (PHP 5.6.40-7+ubuntu16.04.1+deb.sury.org+1 (cli) )
+- PHP 7.0 (PHP 7.0.33-7+ubuntu16.04.1+deb.sury.org+1 (cli) (built: May  3 2019 09:57:01) ( NTS ))
+- PHP 7.1 (PHP 7.1.29-1+ubuntu16.04.1+deb.sury.org+1 (cli) (built: May  3 2019 09:51:08) ( NTS ))
+- PHP 7.2 (PHP 7.2.18-1+ubuntu16.04.1+deb.sury.org+1 (cli) (built: May  3 2019 09:23:41) ( NTS ))
+- PHP 7.3 (PHP 7.3.5-1+ubuntu16.04.1+deb.sury.org+1 (cli) (built: May  3 2019 10:00:05) ( NTS ))
+- Composer  (Composer version 1.8.5 2019-04-09 17:46:47)
+- PHPUnit (PHPUnit 7.5.9 by Sebastian Bergmann and contributors.)
 - Pollinate
 - Powershell (PowerShell 6.2.0)
+- rustup (rustup 1.18.2 (a0bf3c9cb 2019-05-02))
+- Rust (rustc 1.34.1 (fc50f328b 2019-04-24))
+- cargo (cargo 1.34.0 (6789d8a0a 2019-04-01))
+- rustfmt (rustfmt 1.0.3-stable (d6829d6 2019-02-14))
+- clippy (clippy 0.0.212 (726176e 2019-04-18))
+- rustdoc (rustdoc 1.34.1 (fc50f328b 2019-04-24))
+- bindgen (bindgen 0.49.0)
+- cbindgen (cbindgen 0.8.6)
 - Scala
 - Sphinx Open Source Search Server
 - Subversion (svn, version 1.9.3 (r1718519))
@@ -143,7 +149,7 @@ The following software is installed on machines in the Hosted Ubuntu 1604 pool
 - Android Support Repository 47.0.0
 - Android Solver for ConstraintLayout 1.0.2
 - Android Solver for ConstraintLayout 1.0.1
-- Android SDK Platform-Tools 28.0.2
+- Android SDK Platform-Tools 28.0.3
 - Android SDK Platform 28
 - Android SDK Platform 27
 - Android SDK Platform 26
@@ -188,20 +194,23 @@ The following software is installed on machines in the Hosted Ubuntu 1604 pool
 - Android NDK 19.2.5345600
 - Android ConstraintLayout 1.0.2
 - Android ConstraintLayour 1.0.1
-- Az Module (1.0.0)
-## Cached container images
-- jekyll/builder:latest (Digest: sha256:e8986db08783394cd77687bbfda4dc0e66d1f0d47786f0a4626b35f767d47943)
-- mcr.microsoft.com/azure-pipelines/node8-typescript:latest (Digest: sha256:e52e60b9f71183969830a3664279b5d8c799b4b0ec2c25a0686f7c02f6a9669a)
+- Az Module (available through the [Azure PowerShell](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/deploy/azure-powershell?view=azure-devops) task)
+  - Az Module (1.0.0)
+  - Az Module (1.6.0)
+- Cached container images
+  - jekyll/builder:latest (Digest: sha256:5e365df1af3ac10d21880aa22d5f4a83ebf78573fe118c8eea7143688ac358ca)
+  - mcr.microsoft.com/azure-pipelines/node8-typescript:latest (Digest: sha256:e52e60b9f71183969830a3664279b5d8c799b4b0ec2c25a0686f7c02f6a9669a)
 - Python (available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task)
-  - Python 2.7.15
+  - Python 2.7.16
   - Python 3.4.8
-  - Python 3.5.5
+  - Python 3.5.7
   - Python 3.6.8
-  - Python 3.7.2
+  - Python 3.7.3
 - Ruby (available through the [Use Ruby Version](https://go.microsoft.com/fwlink/?linkid=2005989) task)
   - Ruby 2.3.7
-  - Ruby 2.4.4
-  - Ruby 2.5.1
+  - Ruby 2.4.6
+  - Ruby 2.5.5
+  - Ruby 2.6.2
 - Python (Python 2.7.12)
 - pip (pip 8.1.1 from /usr/lib/python2.7/dist-packages (python 2.7))
 - Python3 (Python 3.5.2)

--- a/images/linux/scripts/helpers/containercache.sh
+++ b/images/linux/scripts/helpers/containercache.sh
@@ -29,14 +29,8 @@ for image in "${images[@]}"; do
 done
 
 ## Add container information to the metadata file
-# echo ""
-# DocumentInstalledItem "Cached container images"
-AddSubTitle "Cached container images"
-
-# while read -r line; do
-#     DocumentInstalledItemIndent "$line"
-# done <<< "$(docker images | tail -n +2 | cut -d' ' -f 1)"
+ DocumentInstalledItem "Cached container images"
 
 while read -r line; do
-    DocumentInstalledItem "$line"
+    DocumentInstalledItemIndent "$line"
 done <<< "$(docker images --digests --format '{{.Repository}}:{{.Tag}} (Digest: {{.Digest}})')"


### PR DESCRIPTION
Update the Ubuntu 16.04 readme file with the latest manifest currently rolling out to production and fix the scripts that output the cached container images to avoid listing other things under the Container Images heading.