### PR TITLE
Fix Rust PATH variable

### DIFF
--- a/images/linux/scripts/installers/rust.sh
+++ b/images/linux/scripts/installers/rust.sh
@@ -17,7 +17,7 @@ curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 echo "RUSTUP_HOME=$RUSTUP_HOME" | tee -a /etc/environment
 echo "CARGO_HOME=$CARGO_HOME" | tee -a /etc/environment
-echo "PATH=\"$PATH:$CARGO_HOME/bin\"" | tee -a /etc/environment
+echo "PATH=$CARGO_HOME/bin:$PATH" | tee -a /etc/environment
 
 source $CARGO_HOME/env
 


### PR DESCRIPTION
We’ve faced with issue PATH variable on Ubuntu image - `echo $PATH` returns value with quotes `PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/usr/local/cargo/bin"`. Because of that the first and the last paths aren’t parsed correctly and Rust becomes unavailable in AzDo tasks.