### PR TITLE
Explicitly add Mercurial location to PATH since choco package may fail to do so

### DIFF
--- a/images/win/scripts/Installers/Install-Mercurial.ps1
+++ b/images/win/scripts/Installers/Install-Mercurial.ps1
@@ -5,3 +5,7 @@
 ################################################################################
 
 choco install hg -y
+
+$hgPath = "${env:ProgramFiles}\Mercurial\"
+Add-MachinePathItem $hgPath
+$env:Path = Get-MachinePath


### PR DESCRIPTION
During 151 version generation, choco package didn't set the path. Change script to be less dependend on choco install and make sure Mercurial is added to the path regardless.