### PR TITLE
Remove 4h WinRM timeout from Windows image, let the default happen

### DIFF
--- a/images/win/WindowsContainer1803-Azure.json
+++ b/images/win/WindowsContainer1803-Azure.json
@@ -43,7 +43,6 @@
             "communicator": "winrm",
             "winrm_use_ssl": "true",
             "winrm_insecure": "true",
-            "winrm_timeout": "4h",
             "winrm_username": "packer"
         }
     ],

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -43,7 +43,6 @@
             "communicator": "winrm",
             "winrm_use_ssl": "true",
             "winrm_insecure": "true",
-            "winrm_timeout": "4h",
             "winrm_username": "packer"
         }
     ],

--- a/images/win/vs2019-Server2019-Azure.json
+++ b/images/win/vs2019-Server2019-Azure.json
@@ -44,7 +44,6 @@
             "communicator": "winrm",
             "winrm_use_ssl": "true",
             "winrm_insecure": "true",
-            "winrm_timeout": "4h",
             "winrm_username": "packer"
         }
     ],


### PR DESCRIPTION
WinRM timeout in packer defaults to 30min, let the default happen by removing the currently set timeout of 4h since that is a waste of time when generating images.