### PR TITLE
Fix Linux Python binary path for toolcache validator

### DIFF
--- a/images/linux/scripts/installers/test-toolcache.sh
+++ b/images/linux/scripts/installers/test-toolcache.sh
@@ -23,7 +23,7 @@ if [ -d "$AGENT_TOOLSDIRECTORY/Python" ]; then
       do
          echo "Test $AGENT_TOOLSDIRECTORY/Python/$version_dir:"
          expected_ver=$(echo $version_dir | egrep -o '[0-9]+\.[0-9]+')
-         actual_ver=$($AGENT_TOOLSDIRECTORY/Python/$version_dir/x64/python -c 'import sys;print(sys.version)'| head -1 | egrep -o '[0-9]+\.[0-9]+')
+         actual_ver=$($AGENT_TOOLSDIRECTORY/Python/$version_dir/x64/bin/python -c 'import sys;print(sys.version)'| head -1 | egrep -o '[0-9]+\.[0-9]+')
 
          if [ "$expected_ver" = "$actual_ver" ]; then
                echo "Passed!"


### PR DESCRIPTION
This PR related to related to issue https://github.com/Microsoft/azure-pipelines-image-generation/issues/225 and fixes Python toolcache validation for Linux systems.

**Details:**
During the latest update of Python toolcache artifacts, we removed duplicating symlinks/binaries from Python root folder, and located them in only in `/bin` folder. This PR changes Python path in `test-toolcache.sh` to accord artifacts structure.

**How it was tested:**
- Via Azure VM provisioning
- Via CanaryBuild definition