### PR TITLE
Added composer reference to download packages in parallel to speed up…

### DIFF
--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -244,6 +244,9 @@ php composer-setup.php
 sudo mv composer.phar /usr/bin/composer
 php -r "unlink('composer-setup.php');"
 
+# Composer parallel download
+composer global require hirak/prestissimo
+
 # Install phpunit (for PHP)
 wget -q -O phpunit https://phar.phpunit.de/phpunit-7.phar
 chmod +x phpunit


### PR DESCRIPTION
Added this open plugin to speedup build timelines:
https://github.com/hirak/prestissimo

What actually does is run the downloads in parallel on where the actual install goes much faster

## Benchmark Example
Below times are for a `laravel/laravel` project
288s -> 26s