### PR TITLE
Fix path to extensions in php.ini

### DIFF
--- a/images/win/scripts/Installers/Install-PHP.ps1
+++ b/images/win/scripts/Installers/Install-PHP.ps1
@@ -11,8 +11,8 @@ Import-Module -Name ImageHelpers
 $installDir = "c:\tools\php"
 choco install php -y --force --params "/InstallDir:$installDir"
 
-# curl and mbstring extension needed for tests
-((Get-Content -path $installDir\php.ini -Raw) -replace ';extension=curl','extension=curl' -replace ';extension=mbstring','extension=mbstring') | Set-Content -Path $installDir\php.ini
+# update path to extensions and enable curl and mbstring extensions
+((Get-Content -path $installDir\php.ini -Raw) -replace ';extension=curl','extension=curl' -replace ';extension=mbstring','extension=mbstring' -replace ';extension_dir = "ext"','extension_dir = "ext"') | Set-Content -Path $installDir\php.ini
 
 # Set the PHPROOT environment variable.
 setx PHPROOT $installDir /M


### PR DESCRIPTION
Php install path was moved so the path for extension loading has to be changed in php.ini to avoid loading from the default (c:\php\ext). Instead, change php.ini to load from "ext" folder relative to executable.

Tested modified version of script in a build. Currently running full VS2017 and VS2019 images to verify build but feel confident that change is ok.