### PR TITLE
Consistent Markdown output for cached docker images

### DIFF
--- a/images/win/scripts/Installers/Vs2017/Update-DockerImages.ps1
+++ b/images/win/scripts/Installers/Vs2017/Update-DockerImages.ps1
@@ -33,4 +33,4 @@ The following container images have been cached:
 
 Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description
 
-Add-ContentToMarkdown -Content $(docker images --digests --format "* {{.Repository}}@{{.Digest}}")
+Add-ContentToMarkdown -Content $(docker images --digests --format "* {{.Repository}}:{{.Tag}} (Digest: {{.Digest}})")

--- a/images/win/scripts/Installers/Vs2019/Update-DockerImages.ps1
+++ b/images/win/scripts/Installers/Vs2019/Update-DockerImages.ps1
@@ -34,4 +34,4 @@ The following container images have been cached:
 
 Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description
 
-Add-ContentToMarkdown -Content $(docker images --digests --format "* {{.Repository}}@{{.Digest}}")
+Add-ContentToMarkdown -Content $(docker images --digests --format "* {{.Repository}}:{{.Tag}} (Digest: {{.Digest}})")

--- a/images/win/scripts/Installers/WindowsContainer1803/Update-DockerImages.ps1
+++ b/images/win/scripts/Installers/WindowsContainer1803/Update-DockerImages.ps1
@@ -34,4 +34,4 @@ The following container images have been cached:
 
 Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description
 
-Add-ContentToMarkdown -Content $(docker images --digests --format "* {{.Repository}}:({{.Digest}})")
+Add-ContentToMarkdown -Content $(docker images --digests --format "* {{.Repository}}:{{.Tag}} (Digest: {{.Digest}})")


### PR DESCRIPTION
In the Windows agent images, there's some confusion around which images are actually cached, because unlike the Linux image, the docker tag is not included in the generated documentation, just the SHA of the image.

This PR:
* Ensures docker tag is included in all Windows release notes for cached
docker images
* Makes format of cached docker image release notes consistent across all
images

This works towards making it clearer exactly which base OS the cached docker images are based upon, which will help us make progress on #316 and #722 (which touch on it being unclear which images are available, and the docker images not matching the kernel of the host OS in the agent image)