### PR TITLE
Change Linux Python binary path for toolcache validator

### DIFF
--- a/images/linux/scripts/installers/test-toolcache.sh
+++ b/images/linux/scripts/installers/test-toolcache.sh
@@ -23,7 +23,7 @@ if [ -d "$AGENT_TOOLSDIRECTORY/Python" ]; then
       do
          echo "Test $AGENT_TOOLSDIRECTORY/Python/$version_dir:"
          expected_ver=$(echo $version_dir | egrep -o '[0-9]+\.[0-9]+')
-         actual_ver=$($AGENT_TOOLSDIRECTORY/Python/$version_dir/x64/python -c 'import sys;print(sys.version)'| head -1 | egrep -o '[0-9]+\.[0-9]+')
+         actual_ver=$($AGENT_TOOLSDIRECTORY/Python/$version_dir/x64/bin/python -c 'import sys;print(sys.version)'| head -1 | egrep -o '[0-9]+\.[0-9]+')
 
          if [ "$expected_ver" = "$actual_ver" ]; then
                echo "Passed!"


### PR DESCRIPTION
This PR fixes path to Python binaries in toolcache validation for Linux systems.

**Details:**
During the update of toolcache we reverted rollback of artifacts, and uploaded latest Python versions for Linux. Therefore, we need to revert changes in PR https://github.com/microsoft/azure-pipelines-image-generation/pull/998.

**How it was tested:**
   - Via Azure VM provisioning. 
Link to image-generation build:
https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=9777106&view=results