### PR TITLE
Changes in installer script to pick up latest helm version

### DIFF
--- a/images/linux/scripts/installers/1604/kubernetes-tools.sh
+++ b/images/linux/scripts/installers/1604/kubernetes-tools.sh
@@ -18,11 +18,7 @@ apt-get update
 apt-get install -y kubectl
 
 # Install Helm
-curl -sL https://storage.googleapis.com/kubernetes-helm/helm-v2.14.0-linux-amd64.tar.gz -o helm-v2.14.0-linux-amd64.tar.gz
-tar -zxvf helm-v2.14.0-linux-amd64.tar.gz
-chmod +x linux-amd64/helm
-mv linux-amd64/helm /usr/local/bin/helm
-rm helm-v2.14.0-linux-amd64.tar.gz
+curl -L https://git.io/get_helm.sh | bash
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"

--- a/images/linux/scripts/installers/1804/kubernetes-tools.sh
+++ b/images/linux/scripts/installers/1804/kubernetes-tools.sh
@@ -20,11 +20,7 @@ apt-get update
 apt-get install -y kubectl
 
 # Install Helm
-curl -sL https://storage.googleapis.com/kubernetes-helm/helm-v2.14.0-linux-amd64.tar.gz -o helm-v2.14.0-linux-amd64.tar.gz
-tar -zxvf helm-v2.14.0-linux-amd64.tar.gz
-chmod +x linux-amd64/helm
-mv linux-amd64/helm /usr/local/bin/helm
-rm helm-v2.14.0-linux-amd64.tar.gz
+curl -L https://git.io/get_helm.sh | bash
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"


### PR DESCRIPTION
Change helm download url in azure-pipelines-image-generation.
Also version was hardcoded till now, changed it to pick up latest each time this script is run.
Workitem - https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1560636 