### PR TITLE
Fix Path for Python3 from toolcache, remove Python2 VS installation

### DIFF
--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -49,7 +49,9 @@ Get-ChildItem -Recurse -Depth 4 -Filter install_to_tools_cache.bat | ForEach-Obj
     }
 }
 
-InstallTool($Python34x86Path)
+if ($Python34x86Path) {
+    InstallTool($Python34x86Path)
+}
 
 Set-Location -Path $current
 

--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -4,6 +4,23 @@
 ##  Desc:  Download tool cache
 ################################################################################
 
+Function InstallTool
+{
+    Param
+    (
+        [System.Object]$ExecutablePath
+    )
+
+    Write-Host $ExecutablePath.DirectoryName
+    Set-Location -Path $ExecutablePath.DirectoryName
+    Get-Location | Write-Host
+    if (Test-Path 'tool.zip')
+    {
+        Expand-Archive 'tool.zip' -DestinationPath '.'
+    }
+    cmd.exe /c 'install_to_tools_cache.bat'
+}
+
 $SourceUrl = "https://vstsagenttools.blob.core.windows.net/tools"
 
 $Dest = "C:/"
@@ -21,16 +38,19 @@ $ToolsDirectory = $Dest + $Path
 $current = Get-Location
 Set-Location -Path $ToolsDirectory
 
+$Python34x86Path
 Get-ChildItem -Recurse -Depth 4 -Filter install_to_tools_cache.bat | ForEach-Object {
-    Write-Host $_.DirectoryName
-    Set-Location -Path $_.DirectoryName
-    Get-Location | Write-Host
-    if (Test-Path 'tool.zip')
-    {
-        Expand-Archive 'tool.zip' -DestinationPath '.'
+    #Python 3.4.* x86 have to be installed after x64 since x64 breaks installed x86 version
+    if ($_.DirectoryName -Match "Python\\3.4.*\\x86") {
+        $Python34x86Path = $_
     }
-    cmd.exe /c 'install_to_tools_cache.bat'
+    else {
+        InstallTool($_)
+    }
 }
+
+InstallTool($Python34x86Path)
+
 Set-Location -Path $current
 
 setx AGENT_TOOLSDIRECTORY $ToolsDirectory /M

--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -54,3 +54,7 @@ InstallTool($Python34x86Path)
 Set-Location -Path $current
 
 setx AGENT_TOOLSDIRECTORY $ToolsDirectory /M
+
+#junction point from the previous Python2 directory to the toolcache Python2
+$python2Dir = (Get-Item -Path ($ToolsDirectory + '/Python/2.7*/x64')).FullName
+cmd.exe /c mklink /d "C:\Python27amd64" "$python2Dir"

--- a/images/win/scripts/Installers/Validate-Python.ps1
+++ b/images/win/scripts/Installers/Validate-Python.ps1
@@ -26,7 +26,7 @@ if ($Python3Version -notlike "Python 3.*")
 $python2path = $Env:AGENT_TOOLSDIRECTORY + '/Python/2.7*/x64'
 $python2Dir = Get-Item -Path $python2path
 
-$env:Path = $python2Dir + ";" + $env:Path
+$env:Path = $python2Dir.FullName + ";" + $env:Path
 
 $Python2Version = & $env:comspec "/s /c python --version 2>&1"
 

--- a/images/win/scripts/Installers/Validate-Python.ps1
+++ b/images/win/scripts/Installers/Validate-Python.ps1
@@ -7,7 +7,7 @@
 
 if(Get-Command -Name 'python')
 {
-    Write-Host "Python $(python --version) on path"
+    Write-Host "Python $(& python -V 2>&1) on path"
 }
 else
 {
@@ -15,15 +15,18 @@ else
     exit 1
 }
 
-$Python3Version = $(python --version)
+$Python3Version = $(& python -V 2>&1)
 
 if ($Python3Version -notlike "Python 3.*")
 {
     Write-Error "Python 3 is not in the PATH"
 }
 
-$Python2Path = "C:\Python27amd64"
-$env:Path = $Python2Path + ";" + $env:Path
+
+$python2path = $Env:AGENT_TOOLSDIRECTORY + '/Python/2.7*/x64'
+$python2Dir = Get-Item -Path $python2path
+
+$env:Path = $python2Dir + ";" + $env:Path
 
 $Python2Version = & $env:comspec "/s /c python --version 2>&1"
 

--- a/images/win/scripts/Installers/Vs2017/Install-Python.ps1
+++ b/images/win/scripts/Installers/Vs2017/Install-Python.ps1
@@ -7,7 +7,7 @@
 
 Import-Module -Name ImageHelpers -Force
 
-$python36path = $Env:AGENT_TOOLSDIRECTORY + '/Python/3.6*'
+$python36path = $Env:AGENT_TOOLSDIRECTORY + '/Python/3.6*/x64'
 $pythonDir = Get-Item -Path $python36path
 
 if($pythonDir -is [array])

--- a/images/win/scripts/Installers/Vs2017/Install-Python.ps1
+++ b/images/win/scripts/Installers/Vs2017/Install-Python.ps1
@@ -27,3 +27,4 @@ if ($currentPath | Select-String -SimpleMatch $pythonDir.FullName)
 
 Add-MachinePathItem -PathItem $pythonDir.FullName
 Add-MachinePathItem -PathItem "$($pythonDir.FullName)\Scripts"
+[System.Environment]::SetEnvironmentVariable('PYTHON_HOME', $pythonDir.FullName, [System.EnvironmentVariableTarget]::Machine)

--- a/images/win/scripts/Installers/Vs2017/Install-Python.ps1
+++ b/images/win/scripts/Installers/Vs2017/Install-Python.ps1
@@ -27,4 +27,3 @@ if ($currentPath | Select-String -SimpleMatch $pythonDir.FullName)
 
 Add-MachinePathItem -PathItem $pythonDir.FullName
 Add-MachinePathItem -PathItem "$($pythonDir.FullName)\Scripts"
-[System.Environment]::SetEnvironmentVariable('PYTHON_HOME', $pythonDir.FullName, [System.EnvironmentVariableTarget]::Machine)

--- a/images/win/scripts/Installers/Vs2017/Install-VS2017.ps1
+++ b/images/win/scripts/Installers/Vs2017/Install-VS2017.ps1
@@ -91,7 +91,6 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
                 '--add Component.Android.SDK23 ' + `
                 '--add Microsoft.VisualStudio.Component.TestTools.WebLoadTest ' + `
                 '--add Microsoft.VisualStudio.Web.Mvc4.ComponentGroup ' + `
-                '--add Component.CPython2.x64 ' + `
                 '--add Component.Linux.CMake ' + `
                 '--add Microsoft.Component.PythonTools.UWP ' + `
                 '--remove Component.CPython3.x64 ' + `

--- a/images/win/scripts/Installers/Vs2019/Install-Python.ps1
+++ b/images/win/scripts/Installers/Vs2019/Install-Python.ps1
@@ -7,7 +7,7 @@
 
 Import-Module -Name ImageHelpers -Force
 
-$python37path = $Env:AGENT_TOOLSDIRECTORY + '/Python/3.7*'
+$python37path = $Env:AGENT_TOOLSDIRECTORY + '/Python/3.7*/x64'
 $pythonDir = Get-Item -Path $python37path
 
 if($pythonDir -is [array])

--- a/images/win/scripts/Installers/Vs2019/Install-Python.ps1
+++ b/images/win/scripts/Installers/Vs2019/Install-Python.ps1
@@ -27,3 +27,4 @@ if ($currentPath | Select-String -SimpleMatch $pythonDir.FullName)
 
 Add-MachinePathItem -PathItem $pythonDir.FullName
 Add-MachinePathItem -PathItem "$($pythonDir.FullName)\Scripts"
+[System.Environment]::SetEnvironmentVariable('PYTHON_HOME', $pythonDir.FullName, [System.EnvironmentVariableTarget]::Machine)

--- a/images/win/scripts/Installers/Vs2019/Install-Python.ps1
+++ b/images/win/scripts/Installers/Vs2019/Install-Python.ps1
@@ -27,4 +27,3 @@ if ($currentPath | Select-String -SimpleMatch $pythonDir.FullName)
 
 Add-MachinePathItem -PathItem $pythonDir.FullName
 Add-MachinePathItem -PathItem "$($pythonDir.FullName)\Scripts"
-[System.Environment]::SetEnvironmentVariable('PYTHON_HOME', $pythonDir.FullName, [System.EnvironmentVariableTarget]::Machine)

--- a/images/win/scripts/Installers/Vs2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Vs2019/Install-VS2019.ps1
@@ -62,7 +62,6 @@ Function InstallVS
 }
 
 $WorkLoads = '--allWorkloads --includeRecommended ' + `
-              '--add Component.CPython2.x64 ' + `
               '--add Component.Dotfuscator ' + `
               '--add Component.Linux.CMake ' + `
               '--add Component.UnityEngine.x64 ' + `


### PR DESCRIPTION
**Changes:**
- Python3 Path didn't work because of the missing subfolder. Fixed by adding x64 to the path
`$python36path = $Env:AGENT_TOOLSDIRECTORY + '/Python/3.6*/x64'`
- If we want to use executables for windows toolcache installation then Python 3.4.* x86 have to be installed after x64 since x64 breaks installed x86 version. InstallTool function added to be able to run the separate installation of 3.4.4 x86 after the other versions installation/
- PYTHON_HOME env variable added to be consistent with [MMS provisioner factory script](https://dev.azure.com/mseng/AzureDevOps/_git/MMS.Provisioner?path=%2Fetc%2Ffactory%2Ffactory_UpdateWindowsPath.ps1&version=GBreleases%2Fm152)
- Python2 installation, which comes with VS, removed because it breaks the toolcache python 2.7.16 executable installer. Junction point added from C:\Python27amd64\ to the toolcache Python 2.
- Validate-Python script fixed. `Python3Version` check didn't work previously because of Python2 outputs the version to the stderr, so the test was passed in every case.

**How it was tested:**
- [VS2017 build](https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=9862928&view=results)
- [VS2019 build](https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=9859895&view=results)