### PR TITLE
Remove fix for Python 3.4 installation on Windows

### DIFF
--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -38,7 +38,6 @@ $ToolsDirectory = $Dest + $Path
 $current = Get-Location
 Set-Location -Path $ToolsDirectory
 
-$Python34x86Path
 Get-ChildItem -Recurse -Depth 4 -Filter install_to_tools_cache.bat | ForEach-Object {
     InstallTool($_)
 }

--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -40,17 +40,7 @@ Set-Location -Path $ToolsDirectory
 
 $Python34x86Path
 Get-ChildItem -Recurse -Depth 4 -Filter install_to_tools_cache.bat | ForEach-Object {
-    #Python 3.4.* x86 have to be installed after x64 since x64 breaks installed x86 version
-    if ($_.DirectoryName -Match "Python\\3.4.*\\x86") {
-        $Python34x86Path = $_
-    }
-    else {
-        InstallTool($_)
-    }
-}
-
-if ($Python34x86Path) {
-    InstallTool($Python34x86Path)
+    InstallTool($_)
 }
 
 Set-Location -Path $current

--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -39,6 +39,7 @@ $current = Get-Location
 Set-Location -Path $ToolsDirectory
 
 Get-ChildItem -Recurse -Depth 4 -Filter install_to_tools_cache.bat | ForEach-Object {
+    #In order to work correctly Python 3.4 x86 must be installed after x64, this is achieved by current toolcache catalog structure
     InstallTool($_)
 }
 


### PR DESCRIPTION
Previously we've faced an issue - **Python 3.4.* x86** have to be installed after x64 since x64 breaks installed x86 version, but judging by the installation logs we don't need to change the installation order, x86 versions install after x64 by default. And besides, if we install Python 3.4 last we will get outdated py launcher that has limited functionality e.g. `py -0` doesn't work.

**Changes:**
- Separate installation of Python 3.4.4 x86 removed