### PR TITLE
WindowsServer 1903 - Building 1903 Container images

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -4,7 +4,8 @@ enum ImageType {
     VS2017 = 0
     VS2019 = 1
     Ubuntu1604 = 2
-    WinCon = 3
+    WinCon1803 = 3
+    WinCon1903 = 4
 }
 
 Function Get-PackerTemplatePath {
@@ -14,7 +15,7 @@ Function Get-PackerTemplatePath {
         [Parameter(Mandatory = $True)]
         [ImageType] $ImageType
     )
-    
+
     $relativePath = "N/A"
 
     switch ($ImageType) {
@@ -27,8 +28,11 @@ Function Get-PackerTemplatePath {
         ([ImageType]::Ubuntu1604) {
             $relativePath = "\images\linux\ubuntu1604.json"
         }
-        ([ImageType]::WinCon) {
+        ([ImageType]::WinCon1803) {
             $relativePath = "\images\win\WindowsContainer1803-Azure.json"
+        }
+        ([ImageType]::WinCon1903) {
+            $relativePath = "\images\win\WindowsContainer1903-Azure.json"
         }
     }
 
@@ -73,7 +77,7 @@ Function GenerateResourcesAndImage {
         [Parameter(Mandatory = $True)]
         [string] $AzureLocation
     )
-    
+
     $builderScriptPath = Get-PackerTemplatePath -RepositoryRoot $ImageGenerationRepositoryRoot -ImageType $ImageType
     $ServicePrincipalClientSecret = $env:UserName + [System.GUID]::NewGuid().ToString().ToUpper();
     $InstallPassword = $env:UserName + [System.GUID]::NewGuid().ToString().ToUpper();

--- a/images/win/WindowsContainer1903-Azure.json
+++ b/images/win/WindowsContainer1903-Azure.json
@@ -1,0 +1,211 @@
+{
+    "variables": {
+        "client_id": "{{env `ARM_CLIENT_ID`}}",
+        "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
+        "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
+        "tenant_id": "{{env `ARM_TENANT_ID`}}",
+        "object_id": "{{env `ARM_OBJECT_ID`}}",
+        "resource_group": "{{env `ARM_RESOURCE_GROUP`}}",
+        "storage_account": "{{env `ARM_STORAGE_ACCOUNT`}}",
+        "temp_resource_group_name": "{{env `TEMP_RESOURCE_GROUP_NAME`}}",
+        "location": "{{env `ARM_RESOURCE_LOCATION`}}",
+        "ssh_password": "{{env `SSH_PASSWORD`}}",
+        "virtual_network_name": "{{env `VNET_NAME`}}",
+        "virtual_network_resource_group_name": "{{env `VNET_RESOURCE_GROUP`}}",
+        "virtual_network_subnet_name": "{{env `VNET_SUBNET`}}",
+        "vm_size": "Standard_DS4_v2",
+
+        "image_folder": "C:\\image",
+        "commit_file": "C:\\image\\commit.txt",
+        "metadata_file": "C:\\image\\metadata.txt",
+        "helper_script_folder": "C:\\Program Files\\WindowsPowerShell\\Modules\\",
+        "commit_id": "LATEST",
+        "install_user": "installer",
+        "install_password": null,
+        "capture_name_prefix": "packer"
+    },
+    "builders": [
+        {
+            "name": "vhd",
+            "type": "azure-arm",
+            "client_id": "{{user `client_id`}}",
+            "client_secret": "{{user `client_secret`}}",
+            "subscription_id": "{{user `subscription_id`}}",
+            "object_id": "{{user `object_id`}}",
+            "tenant_id": "{{user `tenant_id`}}",
+            "os_disk_size_gb": "125",
+            "location": "{{user `location`}}",
+            "vm_size": "{{user `vm_size`}}",
+            "resource_group_name": "{{user `resource_group`}}",
+            "storage_account": "{{user `storage_account`}}",
+            "temp_resource_group_name": "{{user `temp_resource_group_name`}}",
+            "capture_container_name": "images",
+            "capture_name_prefix": "{{user `capture_name_prefix`}}",
+            "virtual_network_name": "{{user `virtual_network_name`}}",
+            "virtual_network_resource_group_name": "{{user `virtual_network_resource_group_name`}}",
+            "virtual_network_subnet_name": "{{user `virtual_network_subnet_name`}}",
+            "os_type": "Windows",
+            "image_publisher": "MicrosoftWindowsServer",
+            "image_offer": "WindowsServerSemiAnnual",
+            "image_sku": "Datacenter-Core-1903-with-Containers-smalldisk",
+            "communicator": "winrm",
+            "winrm_use_ssl": "true",
+            "winrm_insecure": "true",
+            "winrm_username": "packer"
+        }
+    ],
+    "provisioners": [
+        {
+            "type": "powershell",
+            "inline":[
+                "New-Item -Path {{user `image_folder`}} -ItemType Directory -Force",
+                "Write-Output {{user `commit_id`}} > {{user `commit_file`}}",
+                "Write-Host (Get-Content -Path {{user `commit_file`}})"
+            ]
+        },
+        {
+            "type": "file",
+            "source": "{{ template_dir }}/scripts/ImageHelpers",
+            "destination": "{{user `helper_script_folder`}}"
+        },
+        {
+            "type": "windows-shell",
+            "inline": [
+                "net user {{user `install_user`}} {{user `install_password`}} /add /passwordchg:no /passwordreq:yes /active:yes" ,
+                "net localgroup Administrators {{user `install_user`}} /add",
+                "winrm set winrm/config/service/auth @{Basic=\"true\"}",
+                "winrm get winrm/config/service/auth"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/WindowsContainer1903/Initialize-VM.ps1"
+            ]
+        },
+        {
+            "type": "windows-restart",
+            "restart_timeout": "30m"
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-ContainersFeature.ps1"
+            ]
+        },
+        {
+            "type": "windows-restart",
+            "restart_timeout": "30m"
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-Docker.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-NodeLts.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-PowershellCore.ps1"
+            ]
+        },
+        {
+            "type": "windows-restart",
+            "restart_timeout": "30m"
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-Docker.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-PowershellCore.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/WindowsContainer1903/Update-DockerImages.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-NodeLts.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-DotnetSDK.ps1"
+            ]
+        },
+        {
+            "type": "windows-restart",
+            "restart_timeout": "30m"
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-DotnetSDK.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-Git.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-Svn.ps1"
+            ]
+        },
+        {
+            "type": "windows-restart",
+            "restart_timeout": "30m"
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-Git.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-Svn.ps1"
+            ]
+        },
+        {
+            "type": "file",
+            "source": "C:\\InstalledSoftware.md",
+            "destination": "{{ template_dir }}/WindowsContainer1903-Readme.md",
+            "direction": "download"
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Finalize-VM.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "inline": [
+                "if( Test-Path $Env:SystemRoot\\System32\\Sysprep\\unattend.xml ){ rm $Env:SystemRoot\\System32\\Sysprep\\unattend.xml -Force}",
+                "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /quiet /quit",
+                "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }"
+            ]
+        }
+    ]
+}

--- a/images/win/WindowsContainer1903-Readme.md
+++ b/images/win/WindowsContainer1903-Readme.md
@@ -1,0 +1,171 @@
+# Azure Pipelines Windows Container 1803 image
+
+The following software is installed on machines in the Azure Pipelines **Windows Container 1903** pool.
+
+Components marked with **\*** have been upgraded since the previous version of the image.
+
+
+## Chocolatey
+
+_Version:_ 0.10.15<br/>
+_Environment:_
+* PATH: contains location for choco.exe
+
+## Docker
+
+_Version:_ 18.09.6<br/>
+_Environment:_
+* PATH: contains location of docker.exe
+
+## Docker-compose
+
+_Version:_ 1.24.0<br/>
+_Environment:_
+* PATH: contains location of docker-compose.exe
+
+## Powershell Core
+
+_Version:_ 6.2.1
+<br/>
+
+## Docker images
+
+The following container images have been cached:
+* mcr.microsoft.com/windows/servercore:1903
+* mcr.microsoft.com/windows/nanoserver:1903
+* mcr.microsoft.com/dotnet/core/aspnet:2.2.6-nanoserver-1903
+* mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-1903
+* mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-1903
+
+## Node.js
+
+_Version:_ 10.16.0<br/>
+_Architecture:_ x64<br/>
+_Environment:_
+* PATH: contains location of node.exe<br/>
+* Gulp CLI version: 2.2.0 Local version: Unknown<br/>
+* Grunt grunt-cli v1.3.2<br/>
+* Bower 1.8.8<br/>
+* Yarn 1.16.0<br/>
+
+> Note: You can install and use another version of Node.js on Microsoft-hosted agent pools using the [Node tool installer](https://docs.microsoft.com/vsts/pipelines/tasks/tool/node-js) task.
+
+## npm
+
+_Version:_ 6.9.0<br/>
+_Environment:_
+* PATH: contains location of npm.cmd
+
+## .NET Core
+
+The following runtimes and SDKs are installed:
+
+_Environment:_
+* PATH: contains location of dotnet.exe
+
+_SDK:_
+* 2.2.105 C:\Program Files\dotnet\sdk\2.2.105
+* 2.2.104 C:\Program Files\dotnet\sdk\2.2.104
+* 2.2.103 C:\Program Files\dotnet\sdk\2.2.103
+* 2.2.102 C:\Program Files\dotnet\sdk\2.2.102
+* 2.2.101 C:\Program Files\dotnet\sdk\2.2.101
+* 2.2.100 C:\Program Files\dotnet\sdk\2.2.100
+* 2.1.505 C:\Program Files\dotnet\sdk\2.1.505
+* 2.1.504 C:\Program Files\dotnet\sdk\2.1.504
+* 2.1.503 C:\Program Files\dotnet\sdk\2.1.503
+* 2.1.502 C:\Program Files\dotnet\sdk\2.1.502
+* 2.1.500 C:\Program Files\dotnet\sdk\2.1.500
+* 2.1.403 C:\Program Files\dotnet\sdk\2.1.403
+* 2.1.402 C:\Program Files\dotnet\sdk\2.1.402
+* 2.1.401 C:\Program Files\dotnet\sdk\2.1.401
+* 2.1.400 C:\Program Files\dotnet\sdk\2.1.400
+* 2.1.4 C:\Program Files\dotnet\sdk\2.1.4
+* 2.1.302 C:\Program Files\dotnet\sdk\2.1.302
+* 2.1.301 C:\Program Files\dotnet\sdk\2.1.301
+* 2.1.300 C:\Program Files\dotnet\sdk\2.1.300
+* 2.1.202 C:\Program Files\dotnet\sdk\2.1.202
+* 2.1.201 C:\Program Files\dotnet\sdk\2.1.201
+* 2.1.200 C:\Program Files\dotnet\sdk\2.1.200
+* 2.1.2 C:\Program Files\dotnet\sdk\2.1.2
+* 2.1.105 C:\Program Files\dotnet\sdk\2.1.105
+* 2.1.104 C:\Program Files\dotnet\sdk\2.1.104
+* 2.1.103 C:\Program Files\dotnet\sdk\2.1.103
+* 2.1.102 C:\Program Files\dotnet\sdk\2.1.102
+* 2.1.101 C:\Program Files\dotnet\sdk\2.1.101
+* 2.1.100 C:\Program Files\dotnet\sdk\2.1.100
+* 2.0.3 C:\Program Files\dotnet\sdk\2.0.3
+* 2.0.0 C:\Program Files\dotnet\sdk\2.0.0
+* 1.1.9 C:\Program Files\dotnet\sdk\1.1.9
+* 1.1.8 C:\Program Files\dotnet\sdk\1.1.8
+* 1.1.7 C:\Program Files\dotnet\sdk\1.1.7
+* 1.1.5 C:\Program Files\dotnet\sdk\1.1.5
+* 1.1.4 C:\Program Files\dotnet\sdk\1.1.4
+* 1.1.13 C:\Program Files\dotnet\sdk\1.1.13
+* 1.1.12 C:\Program Files\dotnet\sdk\1.1.12
+* 1.1.11 C:\Program Files\dotnet\sdk\1.1.11
+* 1.1.10 C:\Program Files\dotnet\sdk\1.1.10
+* 1.0.4 C:\Program Files\dotnet\sdk\1.0.4
+* 1.0.1 C:\Program Files\dotnet\sdk\1.0.1
+
+_Runtime:_
+* 2.2.3 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.2.3
+* 2.2.2 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.2.2
+* 2.2.1 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.2.1
+* 2.2.0 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.2.0
+* 2.1.9 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.9
+* 2.1.8 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.8
+* 2.1.7 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.7
+* 2.1.6 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.6
+* 2.1.5 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.5
+* 2.1.4 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.4
+* 2.1.3 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.3
+* 2.1.2 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.2
+* 2.1.1 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.1
+* 2.1.0 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.0
+* 2.0.9 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.9
+* 2.0.7 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.7
+* 2.0.6 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.6
+* 2.0.5 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.5
+* 2.0.3 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3
+* 2.0.0 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.0
+* 1.1.9 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.1.9
+* 1.1.8 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.1.8
+* 1.1.7 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.1.7
+* 1.1.6 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.1.6
+* 1.1.5 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.1.5
+* 1.1.4 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.1.4
+* 1.1.2 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.1.2
+* 1.1.12 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.1.12
+* 1.1.11 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.1.11
+* 1.1.10 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.1.10
+* 1.1.1 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.1.1
+* 1.0.9 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.0.9
+* 1.0.8 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.0.8
+* 1.0.7 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.0.7
+* 1.0.5 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.0.5
+* 1.0.4 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.0.4
+* 1.0.15 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.0.15
+* 1.0.14 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.0.14
+* 1.0.13 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.0.13
+* 1.0.12 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.0.12
+* 1.0.11 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.0.11
+* 1.0.10 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\1.0.10
+
+## Git
+
+_Version:_ 2.22.0<br/>
+_Environment:_
+* PATH: contains location of git.exe
+
+## Git Large File Storage (LFS)
+
+_Version:_ 2.7.2<br/>
+_Environment:_
+* PATH: contains location of git-lfs.exe
+* GIT_LFS_PATH: location of git-lfs.exe
+
+## Subversion
+
+_Version:_ 1.8.17<br/>
+_Environment:_
+* PATH: contains location of svn.exe

--- a/images/win/scripts/Installers/WindowsContainer1903/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/WindowsContainer1903/Initialize-VM.ps1
@@ -1,0 +1,120 @@
+################################################################################
+##  File:  Initialize-VM.ps1
+##  Team:  CI-Platform
+##  Desc:  VM initialization script, machine level configuration
+################################################################################
+
+function Disable-UserAccessControl {
+    Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" -Name "ConsentPromptBehaviorAdmin" -Value 00000000 -Force
+    Write-Host "User Access Control (UAC) has been disabled."
+}
+
+Import-Module -Name ImageHelpers -Force
+
+Write-Host "Setup PowerShellGet"
+# Set-PSRepository -InstallationPolicy Trusted -Name PSGallery
+Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+Install-Module -Name PowerShellGet -Force
+Set-PSRepository -InstallationPolicy Trusted -Name PSGallery
+
+Write-Host "Disable Antivirus"
+Set-MpPreference -DisableRealtimeMonitoring $true
+
+# Disable Windows Update
+$AutoUpdatePath = "HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU"
+If (Test-Path -Path $AutoUpdatePath) {
+    Set-ItemProperty -Path $AutoUpdatePath -Name NoAutoUpdate -Value 1
+    Write-Host "Disabled Windows Update"
+}
+else {
+    Write-Host "Windows Update key does not exist"
+}
+
+# Insatll Windows .NET Features
+Install-WindowsFeature -Name NET-Framework-45-Features -IncludeAllSubFeature
+Install-WindowsFeature -Name BITS -IncludeAllSubFeature
+Install-WindowsFeature -Name DSC-Service
+
+# Install Data Deduplication filter driver, but don't enable it on any drives
+Install-WindowsFeature -Name FS-Data-Deduplication
+
+Write-Host "Disable UAC"
+Disable-UserAccessControl
+
+Write-Host "Setting local execution policy"
+Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope MachinePolicy -ErrorAction Continue | Out-Null
+Get-ExecutionPolicy -List
+
+Write-Host "Enable long path behavior"
+# See https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file#maximum-path-length-limitation
+Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -Value 1
+
+Write-Host "Install chocolatey"
+$chocoExePath = 'C:\ProgramData\Chocolatey\bin'
+
+if ($($env:Path).ToLower().Contains($($chocoExePath).ToLower())) {
+    Write-Host "Chocolatey found in PATH, skipping install..."
+    Exit
+}
+
+# Add to system PATH
+$systemPath = [Environment]::GetEnvironmentVariable('Path', [System.EnvironmentVariableTarget]::Machine)
+$systemPath += ';' + $chocoExePath
+[Environment]::SetEnvironmentVariable("PATH", $systemPath, [System.EnvironmentVariableTarget]::Machine)
+
+# Update local process' path
+$userPath = [Environment]::GetEnvironmentVariable('Path', [System.EnvironmentVariableTarget]::User)
+if ($userPath) {
+    $env:Path = $systemPath + ";" + $userPath
+}
+else {
+    $env:Path = $systemPath
+}
+
+# Run the installer
+Invoke-Expression ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+
+# Turn off confirmation
+choco feature enable -n allowGlobalConfirmation
+
+# Expand disk size of OS drive
+
+New-Item -Path d:\ -Name cmds.txt -ItemType File -Force
+
+Add-Content -Path d:\cmds.txt "SELECT VOLUME=C`r`nEXTEND"
+
+$expandResult = (diskpart /s 'd:\cmds.txt')
+
+Write-Host $expandResult
+
+Write-Host "Disk sizes after expansion"
+
+wmic logicaldisk get size,freespace,caption
+
+# Adding description of the software to Markdown
+
+$Content = @"
+# Azure Pipelines Windows Container 1803 image
+
+The following software is installed on machines in the Azure Pipelines **Windows Container 1803** pool.
+
+Components marked with **\*** have been upgraded since the previous version of the image.
+
+"@
+
+Add-ContentToMarkdown -Content $Content
+
+$SoftwareName = "Chocolatey"
+
+if( $( $(choco version) | Out-String) -match  'Chocolatey v(?<version>.*).*' )
+{
+   $chocoVersion = $Matches.version.Trim()
+}
+
+$Description = @"
+_Version:_ $chocoVersion<br/>
+_Environment:_
+* PATH: contains location for choco.exe
+"@
+
+Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description

--- a/images/win/scripts/Installers/WindowsContainer1903/Install-VS2017-BuildTools.ps1
+++ b/images/win/scripts/Installers/WindowsContainer1903/Install-VS2017-BuildTools.ps1
@@ -1,0 +1,124 @@
+################################################################################
+##  File:  Install-VS2017-BuildTools.ps1
+##  Team:  CI-Build
+##  Desc:  Install Visual Studio Build Tools 2017
+################################################################################
+
+Function InstallVS
+{
+  Param
+  (
+    [String]$WorkLoads,
+    [String]$Sku,
+    [String] $VSBootstrapperURL
+  )
+
+  $exitCode = -1
+
+  try
+  {
+    Write-Host "Downloading Bootstrapper ..."
+    Invoke-WebRequest -Uri $VSBootstrapperURL -OutFile "${env:Temp}\vs_$Sku.exe"
+
+    $FilePath = "${env:Temp}\vs_$Sku.exe"
+    $Arguments = ('/c', $FilePath, $WorkLoads, '--passive', '--norestart', '--wait', '--nocache' )
+
+    Write-Host "Starting Install ..."
+    $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru
+    $exitCode = $process.ExitCode
+
+    if ($exitCode -eq 0 -or $exitCode -eq 3010)
+    {
+      Write-Host -Object 'Installation successful'
+      return $exitCode
+    }
+    else
+    {
+      Write-Host -Object "Non zero exit code returned by the installation process : $exitCode."
+
+      # this wont work because of log size limitation in extension manager
+      # Get-Content $customLogFilePath | Write-Host
+
+      exit $exitCode
+    }
+  }
+  catch
+  {
+    Write-Host -Object "Failed to install Visual Studio. Check the logs for details in $customLogFilePath"
+    Write-Host -Object $_.Exception.Message
+    exit -1
+  }
+}
+
+$WorkLoads = '--allWorkloads --includeRecommended '
+
+$Sku = 'BuildTools'
+$VSBootstrapperURL = 'https://aka.ms/vs/15/release/vs_BuildTools.exe'
+
+$ErrorActionPreference = 'Stop'
+
+# Install VS
+$exitCode = InstallVS -WorkLoads $WorkLoads -Sku $Sku -VSBootstrapperURL $VSBootstrapperURL
+
+# Find the version of VS installed for this instance
+# Only supports a single instance
+$vsProgramData = Get-Item -Path "C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances"
+$instanceFolders = Get-ChildItem -Path $vsProgramData.FullName
+
+if($instanceFolders -is [array])
+{
+    Write-Host "More than one instance installed"
+    exit 1
+}
+
+$catalogContent = Get-Content -Path ($instanceFolders.FullName + '\catalog.json')
+$catalog = $catalogContent | ConvertFrom-Json
+$version = $catalog.info.id
+Write-Host "Visual Studio version" $version "installed"
+
+# Updating content of MachineState.json file to disable autoupdate of VSIX extensions
+$newContent = '{"Extensions":[{"Key":"1e906ff5-9da8-4091-a299-5c253c55fdc9","Value":{"ShouldAutoUpdate":false}},{"Key":"Microsoft.VisualStudio.Web.AzureFunctions","Value":{"ShouldAutoUpdate":false}}],"ShouldAutoUpdate":false,"ShouldCheckForUpdates":false}'
+Set-Content -Path "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\Common7\IDE\Extensions\MachineState.json" -Value $newContent
+
+
+# Adding description of the software to Markdown
+
+$SoftwareName = "Visual Studio 2017 BuildTools"
+
+$Description = @"
+_Version:_ $version<br/>
+_Location:_ C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools
+
+The following workloads including required and recommended components are installed with Visual Studio 2017:
+
+* Universal Windows Platform development
+* .NET desktop development
+* Desktop development with C++
+* ASP.NET and web development
+* Azure development
+* Node.js development
+* Data storage and processing
+* Data science and analytical applications
+* Game development with Unity
+* Linux development with C++
+* Game development with C++
+* Mobile development with C++
+* Office/SharePoint development
+* Mobile development with .NET
+* .NET Core cross-platform development
+* Visual Studio extension development
+* Python development *
+* Mobile development with JavaScript
+
+In addition the following optional components are installed:
+
+"@
+
+Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description
+
+# Adding explicitly added Workloads details to markdown by parsing $Workloads
+Add-ContentToMarkdown -Content $($WorkLoads.Split('--') | % { if( ($_.Split(" "))[0] -like "add") { "* " +($_.Split(" "))[1] }  } )
+
+
+
+exit $exitCode

--- a/images/win/scripts/Installers/WindowsContainer1903/Update-DockerImages.ps1
+++ b/images/win/scripts/Installers/WindowsContainer1903/Update-DockerImages.ps1
@@ -1,0 +1,36 @@
+################################################################################
+##  File:  Update-DockerImages.ps1
+##  Team:  ReleaseManagement
+##  Desc:  Pull some standard docker images.
+##         Must be run after docker is installed.
+################################################################################
+
+function DockerPull {
+    Param ([string]$image)
+
+    Write-Host Installing $image ...
+    docker pull $image
+
+    if (!$?) {
+      echo "Docker pull failed with a non-zero exit code"
+      exit 1
+    }
+}
+
+DockerPull mcr.microsoft.com/windows/servercore:1903
+DockerPull mcr.microsoft.com/windows/nanoserver:1903
+DockerPull mcr.microsoft.com/dotnet/core/aspnet:2.2.6-nanoserver-1903
+DockerPull mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-1903
+DockerPull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-1903
+
+# Adding description of the software to Markdown
+
+$SoftwareName = "Docker images"
+
+$Description = @"
+The following container images have been cached:
+"@
+
+Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description
+
+Add-ContentToMarkdown -Content $(docker images --digests --format "* {{.Repository}}:{{.Tag}} (Digest: {{.Digest}})")


### PR DESCRIPTION
Building Windows Sever 1903 to enable Azure DevOps to build
1903 container images via the Azure Devops pipeline as currently there is only  windows 1803 option.