### PR TITLE
Adding ATL for ARM and ARM64.

### DIFF
--- a/images/win/scripts/Installers/Vs2017/Install-VS2017.ps1
+++ b/images/win/scripts/Installers/Vs2017/Install-VS2017.ps1
@@ -78,6 +78,8 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
                 '--add Microsoft.VisualStudio.Component.VC.140 ' + `
                 '--add Component.Dotfuscator ' + `
                 '--add Microsoft.VisualStudio.Component.VC.ATL ' + `
+                '--add Microsoft.VisualStudio.Component.VC.ATL.ARM ' + `
+                '--add Microsoft.VisualStudio.Component.VC.ATL.ARM64 ' + `
                 '--add Microsoft.VisualStudio.Component.VC.ATLMFC ' + `
                 '--add Microsoft.VisualStudio.Component.VC.ClangC2 ' + `
                 '--add Microsoft.VisualStudio.Component.VC.CLI.Support ' + `
@@ -115,6 +117,8 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
                 '--add Microsoft.Component.Blend.SDK.WPF ' + `
                 '--add Microsoft.Component.VC.Runtime.UCRTSDK ' + `
                 '--add Microsoft.VisualStudio.Component.VC.ATL.Spectre ' + `
+                '--add Microsoft.VisualStudio.Component.VC.ATL.ARM.Spectre ' + `
+                '--add Microsoft.VisualStudio.Component.VC.ATL.ARM64.Spectre ' + `
                 '--add Microsoft.VisualStudio.Component.VC.ATLMFC.Spectre ' + `
                 '--add Microsoft.VisualStudio.Component.Windows10SDK.17134 ' + `
                 '--add Microsoft.VisualStudio.Component.Windows10SDK.17763 ' + `


### PR DESCRIPTION
Adding bits missing to build ARM project requiring `atls.lib` with both Spectre mitigations and without them. It seems that these bits are already part of VS2019 VM configuration and the VS2017 one contains the runtime components for ATL ARM/ARM64 as well.

This might also resolve issue #931.