### PR TITLE
latest 5.0.2 hg fails to run in 64bit env

### DIFF
--- a/images/win/scripts/Installers/Install-Mercurial.ps1
+++ b/images/win/scripts/Installers/Install-Mercurial.ps1
@@ -4,7 +4,7 @@
 ##  Desc:  Install Mercurial
 ################################################################################
 
-choco install hg -y
+choco install hg -y --version 5.0.0
 
 $hgPath = "${env:ProgramFiles}\Mercurial\"
 Add-MachinePathItem $hgPath


### PR DESCRIPTION
Running latest 5.0.2 hg fails with `ImportError: DLL load failed: %1 is not a valid Win32 application`.  Pinpoint hg to a known good version.