### PR TITLE
Updated the tag for nanoserver in Vs2017

### DIFF
--- a/images/win/scripts/Installers/Vs2017/Update-DockerImages.ps1
+++ b/images/win/scripts/Installers/Vs2017/Update-DockerImages.ps1
@@ -18,7 +18,7 @@ function DockerPull {
 }
 
 DockerPull mcr.microsoft.com/windows/servercore:ltsc2016
-DockerPull mcr.microsoft.com/windows/nanoserver:1803
+DockerPull mcr.microsoft.com/windows/nanoserver:10.0.14393.953
 DockerPull microsoft/aspnetcore-build:1.0-2.0
 DockerPull mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2016
 DockerPull mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2016


### PR DESCRIPTION
The tag for nanoserver in VS2017 currently (1803) is not compatible with the build version of VS2017 (10.0.14393). Updated the tag for VS2017 nanoserver 