### PR TITLE
Revert #1036 for nanoserver on Server 2016

### DIFF
--- a/images/win/scripts/Installers/Vs2017/Update-DockerImages.ps1
+++ b/images/win/scripts/Installers/Vs2017/Update-DockerImages.ps1
@@ -18,7 +18,7 @@ function DockerPull {
 }
 
 DockerPull mcr.microsoft.com/windows/servercore:ltsc2016
-DockerPull mcr.microsoft.com/windows/nanoserver:1803
+DockerPull mcr.microsoft.com/windows/nanoserver:10.0.14393.953
 DockerPull microsoft/aspnetcore-build:1.0-2.0
 DockerPull mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2016
 DockerPull mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2016


### PR DESCRIPTION
We found that `mcr.microsoft.com/windows/nanoserver:1803` is too recent for WS2016, where the Windows version (currently) is 10.0.14393.

There is no version tag mentioned for that Windows version in [this table](https://hub.docker.com/_/microsoft-windows-nanoserver#windows-images), but the previous label still works.

Without this, the image build breaks for VS2017/WS2016:
```
vhd: Installing mcr.microsoft.com/windows/nanoserver:1803 ...
vhd: 1803: Pulling from windows/nanoserver
vhd: Docker pull failed with a non-zero exit code
```