### PR TITLE
change ubuntu1604-readme download dir

### DIFF
--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -188,7 +188,7 @@
         {
             "type": "file",
             "source": "{{user `metadata_file`}}",
-            "destination": "./Ubuntu1604-README.md",
+            "destination": "{{template_dir}}/Ubuntu1604-README.md",
             "direction": "download"
         },
         {

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -194,7 +194,6 @@
         {
             "type": "shell",
             "inline": [
-                "rm {{user `metadata_file`}}",
                 "rm -rf {{user `helper_script_folder`}}",
                 "rm -rf {{user `installer_script_folder`}}",
                 "chmod 755 {{user `image_folder`}}"


### PR DESCRIPTION
The Ubuntu1604-README.md download destination was set to ./ instead of {{template_dir}}. When we run the Update Readme File step during the build image, it cannot find the modified readme file and push no changes in the created PR. 
Changed the download destination to fix this issue.