### PR TITLE
Users/maoswald/fix ctype dot h

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -71,7 +71,9 @@ Function GenerateResourcesAndImage {
         [Parameter(Mandatory = $True)]
         [ImageType] $ImageType,
         [Parameter(Mandatory = $True)]
-        [string] $AzureLocation
+        [string] $AzureLocation,
+        [Parameter(Mandatory = $False)]
+        [int]$SecondsToWaitForServicePrincipalSetup = 30
     )
 
     $builderScriptPath = Get-PackerTemplatePath -RepositoryRoot $ImageGenerationRepositoryRoot -ImageType $ImageType
@@ -108,7 +110,7 @@ Function GenerateResourcesAndImage {
     $spAppId = $sp.ApplicationId
     $spClientId = $sp.ApplicationId
     $spObjectId = $sp.Id
-    Sleep 120
+    Sleep -Seconds $SecondsToWaitForServicePrincipalSetup
 
     New-AzureRmRoleAssignment -RoleDefinitionName Contributor -ServicePrincipalName $spAppId
     $sub = Get-AzureRmSubscription -SubscriptionId $SubscriptionId

--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -14,7 +14,7 @@ Function Get-PackerTemplatePath {
         [Parameter(Mandatory = $True)]
         [ImageType] $ImageType
     )
-    
+
     $relativePath = "N/A"
 
     switch ($ImageType) {
@@ -73,7 +73,7 @@ Function GenerateResourcesAndImage {
         [Parameter(Mandatory = $True)]
         [string] $AzureLocation
     )
-    
+
     $builderScriptPath = Get-PackerTemplatePath -RepositoryRoot $ImageGenerationRepositoryRoot -ImageType $ImageType
     $ServicePrincipalClientSecret = $env:UserName + [System.GUID]::NewGuid().ToString().ToUpper();
     $InstallPassword = $env:UserName + [System.GUID]::NewGuid().ToString().ToUpper();
@@ -108,7 +108,7 @@ Function GenerateResourcesAndImage {
     $spAppId = $sp.ApplicationId
     $spClientId = $sp.ApplicationId
     $spObjectId = $sp.Id
-    Sleep 60
+    Sleep 120
 
     New-AzureRmRoleAssignment -RoleDefinitionName Contributor -ServicePrincipalName $spAppId
     $sub = Get-AzureRmSubscription -SubscriptionId $SubscriptionId

--- a/images/win/vs2019-Server2019-Azure.json
+++ b/images/win/vs2019-Server2019-Azure.json
@@ -147,6 +147,12 @@
         },
         {
             "type": "powershell",
+            "scripts": [
+                "{{ template_dir }}/scripts/Installers/Vs2019/Install-WDK.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
             "valid_exit_codes": [
                 0,
                 3010
@@ -171,12 +177,6 @@
             ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-NET48.ps1"
-            ]
-        },
-        {
-            "type": "powershell",
-            "scripts":[
-                "{{ template_dir }}/scripts/Installers/Vs2019/Install-WDK.ps1"
             ]
         },
         {


### PR DESCRIPTION
This fixes the issue described in [devcommunity ticket 539158](https://developercommunity.visualstudio.com/content/problem/537209/missing-ctypeh-vc-includepath-on-windows-2019-agen.html). The WDK installer overwrites certain include paths and needs to come earlier in the order.