### PR TITLE
Avoid assuming username in image generation scripts.

### DIFF
--- a/images/linux/scripts/installers/1604/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/1604/dotnetcore-sdk.sh
@@ -86,6 +86,6 @@ done
 # NuGetFallbackFolder at /usr/share/dotnet/sdk/NuGetFallbackFolder is warmed up by smoke test
 # Additional FTE will just copy to ~/.dotnet/NuGet which provides no benefit on a fungible machine
 echo "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" | tee -a /etc/environment
-echo "PATH=\"/home/vsts/.dotnet/tools:$PATH\"" | tee -a /etc/environment
+echo "PATH=\"$HOME/.dotnet/tools:\$PATH\"" | tee -a /etc/skel/.profile
 
 dotnet --info

--- a/images/linux/scripts/installers/1804/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/1804/dotnetcore-sdk.sh
@@ -92,4 +92,4 @@ done
 # NuGetFallbackFolder at /usr/share/dotnet/sdk/NuGetFallbackFolder is warmed up by smoke test
 # Additional FTE will just copy to ~/.dotnet/NuGet which provides no benefit on a fungible machine
 echo "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" | tee -a /etc/environment
-echo "PATH=\"/home/vsts/.dotnet/tools:$PATH\"" | tee -a /etc/environment
+echo "PATH=\"$HOME/.dotnet/tools:\$PATH\"" | tee -a /etc/skel/.profile

--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -51,4 +51,14 @@ $dotnetReleases | ForEach-Object {
 }
 
 Add-MachinePathItem "C:\Program Files\dotnet"
-Add-MachinePathItem "C:\Users\VssAdministrator\.dotnet\tools"
+# Run script at startup for all users
+$cmdDotNetPath = @"
+@echo off
+SETX PATH "%USERPROFILE%\.dotnet\tools;%PATH%"
+"@
+
+$cmdPath = "C:\Program Files\dotnet\userpath.bat"
+$cmdDotNetPath | Out-File -Encoding ascii -FilePath $cmdPath
+
+# Update Run key to run a script at logon
+Set-ItemProperty -Path "HKLM:\Software\Microsoft\Windows\CurrentVersion\Run" -Name "DOTNETUSERPATH" -Value $cmdPath

--- a/images/win/scripts/Installers/Validate-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Validate-DotnetSDK.ps1
@@ -14,17 +14,6 @@ else
     exit 1
 }
 
-$CurrentPath = Get-MachinePath
-if ($CurrentPath -Like "*C:\Users\VssAdministrator\.dotnet\tools*")
-{
-    Write-Host ".Net Core global tool path (C:\Users\VssAdministrator\.dotnet\tools) is added to system path envrionment variable."
-}
-else
-{
-    Write-Host ".Net Core global tool path is not on system path"
-    exit 1
-}
-
 # Adding description of the software to Markdown
 $SoftwareName = ".NET Core"
 


### PR DESCRIPTION
A couple of scripts have code to assume the user that will be created in the VM off the image later on. This only serves hosted AzP builds and causes problems for self-hosted agents created by 3rd parties. Fix scripts to generalize userprofile settings.