### PR TITLE
Add missing escape character for $

### DIFF
--- a/images/linux/scripts/installers/1604/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/1604/dotnetcore-sdk.sh
@@ -86,6 +86,6 @@ done
 # NuGetFallbackFolder at /usr/share/dotnet/sdk/NuGetFallbackFolder is warmed up by smoke test
 # Additional FTE will just copy to ~/.dotnet/NuGet which provides no benefit on a fungible machine
 echo "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" | tee -a /etc/environment
-echo "PATH=\"$HOME/.dotnet/tools:\$PATH\"" | tee -a /etc/skel/.profile
+echo "PATH=\"\$HOME/.dotnet/tools:\$PATH\"" | tee -a /etc/skel/.profile
 
 dotnet --info

--- a/images/linux/scripts/installers/1804/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/1804/dotnetcore-sdk.sh
@@ -92,4 +92,4 @@ done
 # NuGetFallbackFolder at /usr/share/dotnet/sdk/NuGetFallbackFolder is warmed up by smoke test
 # Additional FTE will just copy to ~/.dotnet/NuGet which provides no benefit on a fungible machine
 echo "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" | tee -a /etc/environment
-echo "PATH=\"$HOME/.dotnet/tools:\$PATH\"" | tee -a /etc/skel/.profile
+echo "PATH=\"\$HOME/.dotnet/tools:\$PATH\"" | tee -a /etc/skel/.profile


### PR DESCRIPTION
The .profile entry should have "$HOME" and not what it expands to at time of creating. Fix script to escape the $ character.