### PR TITLE
macos 1013 week 31 updates

### DIFF
--- a/images/macos/macos-10.13-Readme.md
+++ b/images/macos/macos-10.13-Readme.md
@@ -567,7 +567,6 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
 
 ### Xamarin.iOS SDK
 
-- 12.99.1.27
 - 12.8.0.2
 - 12.6.0.25
 - 12.2.1.16
@@ -602,7 +601,6 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
 
 ### Xamarin.Mac SDK
 
-- 5.99.1.27
 - 5.8.0.0
 - 5.6.0.25
 - 5.3.1.28

--- a/images/macos/macos-10.13-Readme.md
+++ b/images/macos/macos-10.13-Readme.md
@@ -19,20 +19,20 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
 
 ### Language and Runtime
 
-- Java 1.7: OpenJDK RE (Zulu 7.29.0.5-CA) (build 1.7.0_222-b08)
-- Java 1.8: OpenJDK RE (Zulu 8.38.0.13-CA) (build 1.8.0_212-b04) (default)
-- Java 11: OpenJDK RE Zulu11.31+11-CA (build 11.0.3+7-LTS)
-- Java 12: OpenJDK RE Zulu12.2+3-CA (build 12.0.1+12)
+- Java 1.7: OpenJDK RE (Zulu 7.31.0.5-CA-macosx) (build 1.7.0_232-b6)
+- Java 1.8: OpenJDK RE (Zulu 8.40.0.25-CA-macosx) (build 1.8.0_222-b10) (default)
+- Java 11: OpenJDK RE Zulu11.33+15-CA (build 11.0.4+11-LTS)
+- Java 12: OpenJDK RE Zulu12.3+11-CA (build 12.0.2+3)
 - Node.js 6.17.0
 - NVM 0.33.11
 - NVM - Installed node versions:
 	v6.17.1
 	v8.16.0
 	v10.16.0
-	v12.6.0
-- PowerShell 6.2.1
+	v12.7.0
+- PowerShell 6.2.2
 - Python 2.7.16
-- Python 3.7.3
+- Python 3.7.4
 - Ruby 2.6.3p62
 - .NET Core SDK 1.0.1, 1.0.4, 1.1.4, 1.1.5, 1.1.7, 1.1.8, 1.1.9, 1.1.10, 1.1.11, 1.1.12, 1.1.13, 2.0.0, 2.0.3, 2.1.100, 2.1.101, 2.1.102, 2.1.103, 2.1.104, 2.1.105, 2.1.503, 2.1.504, 2.1.505, 2.1.2, 2.1.200, 2.1.201, 2.1.300, 2.1.301, 2.1.4, 2.1.400, 2.1.401 2.1.402 2.1.502, 2.1.504, 2.2.101, 2.2.102, 2.2.103, 2.2.104, 2.2.105
 - Go 1.12.7
@@ -41,10 +41,10 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
 
 - Bundler 2.0.2
 - Carthage 0.33.0
-- CocoaPods 1.7.3 (Please, pay attention here. You may face an issue with pod install due to old dependencies in your pod file. In that case, you need to update your pod file with newer dependencies or rollback to an older CocoaPods version using this [post-clone script](https://github.com/microsoft/appcenter/tree/master/sample-build-scripts/general/cocoapods-rollback))
-- Homebrew 2.1.7
+- CocoaPods 1.7.5 (Please, pay attention here. You may face an issue with pod install due to old dependencies in your pod file. In that case, you need to update your pod file with newer dependencies or rollback to an older CocoaPods version using this [post-clone script](https://github.com/microsoft/appcenter/tree/master/sample-build-scripts/general/cocoapods-rollback))
+- Homebrew 2.1.8
 - NPM 3.10.10
-- Yarn 1.16.0
+- Yarn 1.17.3
 - NuGet 4.7.0.5148
 - pip 19.1.1(python 2.7)
 - pip 19.1.1(python 3.7)
@@ -53,30 +53,30 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
 ### Project Management
 
 - Apache Maven 3.6.1
-- Gradle 5.5
+- Gradle 5.5.1
 
 ### Utilities
 
-- curl 7.65.1 (libcurl/7.65.1 SecureTransport zlib/1.2.11)
+- curl 7.65.3 (libcurl/7.65.3 SecureTransport zlib/1.2.11)
 - Git 2.22.0
-- Git LFS 2.7.2
+- Git LFS 2.8.0
 - GNU Wget 1.20.3
-- Subversion (SVN) 1.12.0
-- GNU parallel 20190622
+- Subversion (SVN) 1.12.2
+- GNU parallel 20190722
 
 ### Tools
 
-- fastlane 2.126.0
-- App Center CLI 1.1.19
-- Azure-CLI 2.0.68
+- fastlane 2.128.0
+- App Center CLI 1.2.2
+- Azure-CLI 2.0.69
 
 ### Pre-cached tools
 - Python (available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task)
-  - 2.7.15
-  - 3.4.8
-  - 3.5.5
-  - 3.6.8
-  - 3.7.2
+  - 2.7.16
+  - 3.4.10
+  - 3.5.7
+  - 3.6.9
+  - 3.7.4
   - pypy2
   - pypy3
 - Ruby (available through the [Use Ruby Version](https://go.microsoft.com/fwlink/?linkid=2005989) task)
@@ -214,7 +214,7 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
 | iOS 10.0 | 14A345 |
 | iOS 10.1 | 14B72 |
 | iOS 10.2 | 14C89 |
-| iOS 10.3 | 14E269 |
+| iOS 10.3 | 14E8301 |
 | iOS 11.1 | 15B87 |
 | iOS 11.2 | 15C107 |
 | iOS 11.3 | 15E217 |
@@ -292,7 +292,7 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
 - iPad Pro (9.7 inch)
 - iPad Pro (12.9 inch)
 
-#### iOS 10.1, 10.2, 10.3
+#### iOS 10.1, 10.2
 
 - iPhone 5
 - iPhone 5s
@@ -307,6 +307,25 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
 - iPad Air 2
 - iPad Pro (9.7 inch)
 - iPad Pro (12.9 inch)
+
+#### iOS 10.3
+
+- iPhone 5
+- iPhone 5s
+- iPhone 6
+- iPhone 6 Plus
+- iPhone 6s
+- iPhone 6s Plus
+- iPhone 7
+- iPhone 7 Plus
+- iPhone SE
+- iPad Air
+- iPad Air 2
+- iPad Pro (9.7 inch)
+- iPad Pro (12.9 inch)
+- iPad (5th generation)
+- iPad Pro (12.9-inch) (2nd generation)
+- iPad Pro (10.5-inch)
 
 #### iOS 11.0, 11.1, 11.2, 11.3, 11.4
 
@@ -530,7 +549,7 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
 
 ### Visual Studio for Mac
 
-- 8.1.4.5
+- 8.1.5.9
 
 ### Mono
 
@@ -548,6 +567,7 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
 
 ### Xamarin.iOS SDK
 
+- 12.99.1.27
 - 12.8.0.2
 - 12.6.0.25
 - 12.2.1.16
@@ -582,6 +602,7 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
 
 ### Xamarin.Mac SDK
 
+- 5.99.1.27
 - 5.8.0.0
 - 5.6.0.25
 - 5.3.1.28


### PR DESCRIPTION
    Python 3.7.4
    Git LFS: git-lfs/2.8.0 (GitHub; darwin amd64; go 1.12.7)
    curl 7.65.3 (x86_64-apple-darwin17.7.0) libcurl/7.65.3 SecureTransport zlib/1.2.11
    Homebrew 2.1.8
    CocoaPods 1.7.5
    App Center CLI 1.2.2
    fastlane 2.128.0
    Gradle 5.5.1
    PowerShell 6.2.2
    Yarn 1.17.3
    java 1.7 : OpenJDK Runtime Environment (Zulu 7.31.0.5-CA-macosx) (build 1.7.0_232-b6)
    java 1.8 : OpenJDK Runtime Environment (Zulu 8.40.0.25-CA-macosx) (build 1.8.0_222-b10) (default)
    java 11 : OpenJDK Runtime Environment Zulu11.33+15-CA (build 11.0.4+11-LTS)
    java 12 : OpenJDK Runtime Environment Zulu12.3+11-CA (build 12.0.2+3)
    azure-cli 2.0.69
    Subversion (SVN) 1.12.2
    NVM v12.7.0 *
    macOS toolcache Python 2.7.16 3.4.10 3.5.7 3.6.9 3.7.4
    GNU parallel 20190722

Xamarin:

    Visual Studio for Mac: 8.1.5.9
