### PR TITLE
Pin Miniconda 4.6.14 on Windows

### DIFF
--- a/images/win/scripts/Installers/Install-Miniconda.ps1
+++ b/images/win/scripts/Installers/Install-Miniconda.ps1
@@ -6,7 +6,10 @@
 
 Import-Module -Name ImageHelpers -Force
 
-$url = "https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe"
+# Lock to Miniconda 4.6 until we do the work to run `conda init` for the vsts user
+# Then we can go back to installing the latest Miniconda
+# $url = "https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe"
+$url = "https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Windows-x86_64.exe"
 $name = $Url.Split('/')[-1]
 $destination = "C:\Miniconda"
 


### PR DESCRIPTION
Conda 4.7 introduced a breaking change for CI builds.

Instead of installing latest, install 4.6.14.  We'll need to do some work for M157 to unblock the upgrade.  Note that users can still break themselves by updating Conda during the run.

**Testing**
Built the VS2017 and VS2019 images (only including the Miniconda step).  Tested a pipeline that repros the break on the VS2017 image.