### PR TITLE
Added Ruby Docker images to Ubuntu base vm images

### DIFF
--- a/images/linux/scripts/installers/docker.sh
+++ b/images/linux/scripts/installers/docker.sh
@@ -28,6 +28,10 @@ docker pull alpine:3.7
 docker pull alpine:3.8
 docker pull alpine:3.9
 docker pull alpine:3.10
+docker pull ruby:2.5
+docker pull ruby:2.6
+docker pull ruby:2.5-alpine
+docker pull ruby:2.6-alpine
 
 ## Add version information to the metadata file
 echo "Documenting Docker version"


### PR DESCRIPTION
Adds Ruby Docker images to those images cached in the base vm for Azure. This will speed up builds for Ruby based projects.

* ruby:2.5
* ruby:2.6
* ruby:2.5-alpine
* ruby:2.6-alpine