### PR TITLE
Add image version ubuntu18

### DIFF
--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -18,7 +18,8 @@
         "installer_script_folder": "/imagegeneration/installers",
         "helper_script_folder": "/imagegeneration/helpers",
         "vm_size": "Standard_DS2_v2",
-        "capture_name_prefix": "packer"
+        "capture_name_prefix": "packer",
+        "image_version": "dev"
     },
     "builders": [
         {
@@ -99,6 +100,13 @@
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}"
+            ],
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
+            "type": "shell",
+            "inline": [
+                "echo ImageVersion={{user `image_version`}} | tee -a /etc/environment"
             ],
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -201,7 +201,6 @@
         {
             "type": "shell",
             "inline": [
-                "rm {{user `metadata_file`}}",
                 "rm -rf {{user `helper_script_folder`}}",
                 "rm -rf {{user `installer_script_folder`}}",
                 "chmod 755 {{user `image_folder`}}"


### PR DESCRIPTION
Add image version to environment variable. 
The metadata_file for readme file shouldn't be deleted after download. We will lose this file if the download fail. Same change had been made to ubuntu16.