### PR TITLE
Add AWS, Google Cloud, and Zeit Now CLIs to Ubuntu images

### DIFF
--- a/images/linux/scripts/installers/aws.sh
+++ b/images/linux/scripts/installers/aws.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+################################################################################
+##  File:  aws.sh
+##  Team:  CI-Platform
+##  Desc:  Installs the AWS CLI
+################################################################################
+
+# Source the helpers
+source $HELPER_SCRIPTS/document.sh
+
+# Install the AWS CLI
+curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+unzip awscli-bundle.zip
+rm awscli-bundle.zip
+./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+
+# Validate the installation
+echo "Validate the installation"
+if ! command -v aws; then
+    echo "aws was not installed"
+    exit 1
+fi
+
+# Document the installed version
+echo "Document the installed version"
+DocumentInstalledItem "AWS CLI ($(aws --version 2>&1))"

--- a/images/linux/scripts/installers/aws.sh
+++ b/images/linux/scripts/installers/aws.sh
@@ -11,8 +11,9 @@ source $HELPER_SCRIPTS/document.sh
 # Install the AWS CLI
 curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
 unzip awscli-bundle.zip
-rm awscli-bundle.zip
 ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+rm awscli-bundle.zip
+rm -rf awscli-bundle
 
 # Validate the installation
 echo "Validate the installation"

--- a/images/linux/scripts/installers/google-cloud-sdk.sh
+++ b/images/linux/scripts/installers/google-cloud-sdk.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+################################################################################
+##  File:  google-cloud-sdk.sh
+##  Team:  CI-Platform
+##  Desc:  Installs the Google Cloud SDK
+################################################################################
+
+# Source the helpers
+source $HELPER_SCRIPTS/document.sh
+
+# Install the Google Cloud SDK
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+sudo apt-get update -y
+sudo apt-get install -y google-cloud-sdk
+
+# Validate the installation
+echo "Validate the installation"
+if ! command -v gcloud; then
+    echo "gcloud was not installed"
+    exit 1
+fi
+
+# Document the installed version
+echo "Document the installed version"
+DocumentInstalledItem "Google Cloud SDK ($(gcloud --version | head -n 1 | cut -d ' ' -f 4))"

--- a/images/linux/scripts/installers/zeit-now.sh
+++ b/images/linux/scripts/installers/zeit-now.sh
@@ -9,10 +9,7 @@
 source $HELPER_SCRIPTS/document.sh
 
 # Install the Zeit Now CLI
-curl -sfLS https://zeit.co/download.sh > download.sh
-chmod +x ./download.sh
-./download.sh --force
-rm ./download.sh
+npm i -g now
 
 # Validate the installation
 echo "Validate the installation"

--- a/images/linux/scripts/installers/zeit-now.sh
+++ b/images/linux/scripts/installers/zeit-now.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+################################################################################
+##  File:  zeit-now.sh
+##  Team:  CI-Platform
+##  Desc:  Installs the Zeit Now CLI
+################################################################################
+
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/document.sh
+
+# Install the Zeit Now CLI
+curl -sfLS https://zeit.co/download.sh > download.sh
+chmod +x ./download.sh
+./download.sh --force
+rm ./download.sh
+
+# Validate the installation
+echo "Validate the installation"
+if ! command -v now; then
+    echo "Zeit Now CLI was not installed"
+    exit 1
+fi
+
+# Document the installed version
+echo "Document the installed version"
+DocumentInstalledItem "Zeit Now CLI ($(now --version))"

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -112,11 +112,11 @@
             "scripts": [
                 "{{template_dir}}/scripts/installers/7-zip.sh",
                 "{{template_dir}}/scripts/installers/ansible.sh",
-                "{{template_dir}}/scripts/installers/aws.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
                 "{{template_dir}}/scripts/installers/azure-cli.sh",
                 "{{template_dir}}/scripts/installers/azure-devops-cli.sh",
                 "{{template_dir}}/scripts/installers/1604/basic.sh",
+                "{{template_dir}}/scripts/installers/aws.sh",
                 "{{template_dir}}/scripts/installers/build-essential.sh",
                 "{{template_dir}}/scripts/installers/clang.sh",
                 "{{template_dir}}/scripts/installers/cmake.sh",

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -112,6 +112,7 @@
             "scripts": [
                 "{{template_dir}}/scripts/installers/7-zip.sh",
                 "{{template_dir}}/scripts/installers/ansible.sh",
+                "{{template_dir}}/scripts/installers/aws.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
                 "{{template_dir}}/scripts/installers/azure-cli.sh",
                 "{{template_dir}}/scripts/installers/azure-devops-cli.sh",
@@ -129,6 +130,7 @@
                 "{{template_dir}}/scripts/installers/git.sh",
                 "{{template_dir}}/scripts/installers/1604/go.sh",
                 "{{template_dir}}/scripts/installers/google-chrome.sh",
+                "{{template_dir}}/scripts/installers/google-cloud-sdk.sh",
                 "{{template_dir}}/scripts/installers/haskell.sh",
                 "{{template_dir}}/scripts/installers/heroku.sh",
                 "{{template_dir}}/scripts/installers/hhvm.sh",
@@ -151,7 +153,8 @@
                 "{{template_dir}}/scripts/installers/sphinx.sh",
                 "{{template_dir}}/scripts/installers/subversion.sh",
                 "{{template_dir}}/scripts/installers/terraform.sh",
-                "{{template_dir}}/scripts/installers/vcpkg.sh"
+                "{{template_dir}}/scripts/installers/vcpkg.sh",
+                "{{template_dir}}/scripts/installers/zeit-now.sh"
             ],
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -115,7 +115,6 @@
             "scripts": [
                 "{{template_dir}}/scripts/installers/7-zip.sh",
                 "{{template_dir}}/scripts/installers/ansible.sh",
-                "{{template_dir}}/scripts/installers/aws.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
                 "{{template_dir}}/scripts/installers/azure-cli.sh",
                 "{{template_dir}}/scripts/installers/azure-devops-cli.sh",

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -120,6 +120,7 @@
                 "{{template_dir}}/scripts/installers/azure-cli.sh",
                 "{{template_dir}}/scripts/installers/azure-devops-cli.sh",
                 "{{template_dir}}/scripts/installers/1804/basic.sh",
+                "{{template_dir}}/scripts/installers/aws.sh",
                 "{{template_dir}}/scripts/installers/build-essential.sh",
                 "{{template_dir}}/scripts/installers/clang.sh",
                 "{{template_dir}}/scripts/installers/cmake.sh",

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -115,6 +115,7 @@
             "scripts": [
                 "{{template_dir}}/scripts/installers/7-zip.sh",
                 "{{template_dir}}/scripts/installers/ansible.sh",
+                "{{template_dir}}/scripts/installers/aws.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
                 "{{template_dir}}/scripts/installers/azure-cli.sh",
                 "{{template_dir}}/scripts/installers/azure-devops-cli.sh",
@@ -132,6 +133,7 @@
                 "{{template_dir}}/scripts/installers/git.sh",
                 "{{template_dir}}/scripts/installers/1804/go.sh",
                 "{{template_dir}}/scripts/installers/google-chrome.sh",
+                "{{template_dir}}/scripts/installers/google-cloud-sdk.sh",
                 "{{template_dir}}/scripts/installers/haskell.sh",
                 "{{template_dir}}/scripts/installers/heroku.sh",
                 "{{template_dir}}/scripts/installers/hhvm.sh",
@@ -154,7 +156,8 @@
                 "{{template_dir}}/scripts/installers/sphinx.sh",
                 "{{template_dir}}/scripts/installers/subversion.sh",
                 "{{template_dir}}/scripts/installers/terraform.sh",
-                "{{template_dir}}/scripts/installers/vcpkg.sh"
+                "{{template_dir}}/scripts/installers/vcpkg.sh",
+                "{{template_dir}}/scripts/installers/zeit-now.sh"
             ],
             "environment_vars": [
                 "METADATA_FILE={{user `metadata_file`}}",


### PR DESCRIPTION
Add install scripts for AWS, Google Cloud, and Zeit Now CLIs to Ubuntu 16.04 and Ubuntu 18.04 images. Original work by @davidstaheli in #1025, moving here to check against latest master and include Ubuntu 18 change. 