### PR TITLE
Disable Git Credential Manager on install

### DIFF
--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -10,6 +10,9 @@ Import-Module -Name ImageHelpers
 # See https://chocolatey.org/packages/git
 choco install git -y --package-parameters="/GitAndUnixToolsOnPath /WindowsTerminal /NoShellIntegration"
 
+# Disable GCM machine-wide
+[Environment]::SetEnvironmentVariable("GCM_VALIDATE", "false", [System.EnvironmentVariableTarget]::Machine)
+
 Add-MachinePathItem "C:\Program Files\Git\mingw64\bin"
 Add-MachinePathItem "C:\Program Files\Git\usr\bin"
 Add-MachinePathItem "C:\Program Files\Git\bin"

--- a/images/win/scripts/Installers/Install-Git.ps1
+++ b/images/win/scripts/Installers/Install-Git.ps1
@@ -11,7 +11,7 @@ Import-Module -Name ImageHelpers
 choco install git -y --package-parameters="/GitAndUnixToolsOnPath /WindowsTerminal /NoShellIntegration"
 
 # Disable GCM machine-wide
-[Environment]::SetEnvironmentVariable("GCM_VALIDATE", "false", [System.EnvironmentVariableTarget]::Machine)
+[Environment]::SetEnvironmentVariable("GCM_INTERACTIVE", "Never", [System.EnvironmentVariableTarget]::Machine)
 
 Add-MachinePathItem "C:\Program Files\Git\mingw64\bin"
 Add-MachinePathItem "C:\Program Files\Git\usr\bin"


### PR DESCRIPTION
Some builds hang when Git auth fails and the GCM kicks in. Since the GCM is interactive, it will hang there but the user has no way to provide input. With this change, I'm disabling GCM on install to avoid this scenario.

Note that the choco package supports /NoCredentialManager but that only sets the variable at the user level. Since the user doing the install is different to that running any builds, we need to make sure we set it machine-wide.