### PR TITLE
Stamp image version in readme output

### DIFF
--- a/images/linux/Ubuntu1804-README.md
+++ b/images/linux/Ubuntu1804-README.md
@@ -1,3 +1,3 @@
 # Hosted Ubuntu 1804 Image (Ubuntu 18.04 LTS)
-The following software is installed on machines in the Hosted Ubuntu 1604 pool
+The following software is installed on machines in the Hosted Ubuntu 1804 pool
 ***

--- a/images/linux/scripts/installers/1604/preparemetadata.sh
+++ b/images/linux/scripts/installers/1604/preparemetadata.sh
@@ -9,5 +9,5 @@
 source $HELPER_SCRIPTS/document.sh
 
 AddTitle "Hosted Ubuntu 1604 Image ($(lsb_release -ds))"
-WriteItem "The following software is installed on machines in the Hosted Ubuntu 1604 pool"
+WriteItem "The following software is installed on machines in the Hosted Ubuntu 1604 ($IMAGE_VERSION) pool"
 WriteItem "***"

--- a/images/linux/scripts/installers/1804/preparemetadata.sh
+++ b/images/linux/scripts/installers/1804/preparemetadata.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+################################################################################
+##  File:  preparemetadata.sh
+##  Team:  CI-Platform
+##  Desc:  This script adds a image title information to the metadata
+##         document
+################################################################################
+
+source $HELPER_SCRIPTS/document.sh
+
+AddTitle "Hosted Ubuntu 1804 Image ($(lsb_release -ds))"
+WriteItem "The following software is installed on machines in the Hosted Ubuntu 1804 (v$IMAGE_VERSION) pool"
+WriteItem "***"

--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -92,9 +92,10 @@
         {
             "type": "shell",
             "scripts":[
-                "{{template_dir}}/scripts/base/preparemetadata.sh"
+                "{{template_dir}}/scripts/installers/1604/preparemetadata.sh"
             ],
             "environment_vars": [
+                "IMAGE_VERSION={{user `image_version`}}",
                 "METADATA_FILE={{user `metadata_file`}}",
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}"
             ],

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -95,9 +95,10 @@
         {
             "type": "shell",
             "scripts":[
-                "{{template_dir}}/scripts/base/preparemetadata.sh"
+                "{{template_dir}}/scripts/installers/1804/preparemetadata.sh"
             ],
             "environment_vars": [
+                "IMAGE_VERSION={{user `image_version`}}",
                 "METADATA_FILE={{user `metadata_file`}}",
                 "HELPER_SCRIPTS={{user `helper_script_folder`}}"
             ],

--- a/images/win/WindowsContainer1803-Azure.json
+++ b/images/win/WindowsContainer1803-Azure.json
@@ -80,6 +80,9 @@
         },
         {
             "type": "powershell",
+            "environment_vars": [
+                "ImageVersion={{user `image_version`}}"
+            ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/WindowsContainer1803/Initialize-VM.ps1"
             ]

--- a/images/win/scripts/Installers/Vs2017/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Vs2017/Initialize-VM.ps1
@@ -122,7 +122,7 @@ wmic logicaldisk get size,freespace,caption
 $Content = @"
 # Azure Pipelines Hosted VS2017 image
 
-The following software is installed on machines in the Azure Pipelines **Hosted VS2017** pool.
+The following software is installed on machines in the Azure Pipelines **Hosted VS2017** (v$env:ImageVersion) pool.
 
 Components marked with **\*** have been upgraded since the previous version of the image.
 

--- a/images/win/scripts/Installers/Vs2019/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/Vs2019/Initialize-VM.ps1
@@ -49,7 +49,7 @@ else {
 
 # Install .NET Framework 3.5 (required by Chocolatey)
 Install-WindowsFeature -Name NET-Framework-Features -IncludeAllSubFeature
-# Explicitly install all 4.7 sub features to include ASP.Net. 
+# Explicitly install all 4.7 sub features to include ASP.Net.
 # As of  1/16/2019, WinServer 19 lists .Net 4.7 as NET-Framework-45-Features
 Install-WindowsFeature -Name NET-Framework-45-Features -IncludeAllSubFeature
 
@@ -121,7 +121,7 @@ wmic logicaldisk get size,freespace,caption
 $Content = @"
 # Azure Pipelines Hosted Windows 2019 with VS2019 image
 
-The following software is installed on machines in the Azure Pipelines **Hosted Windows 2019 with VS2019** pool.
+The following software is installed on machines in the Azure Pipelines **Hosted Windows 2019 with VS2019** (v$env:ImageVersion) pool.
 
 Components marked with **\*** have been upgraded since the previous version of the image.
 

--- a/images/win/scripts/Installers/WindowsContainer1803/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/WindowsContainer1803/Initialize-VM.ps1
@@ -96,7 +96,7 @@ wmic logicaldisk get size,freespace,caption
 $Content = @"
 # Azure Pipelines Windows Container 1803 image
 
-The following software is installed on machines in the Azure Pipelines **Windows Container 1803** pool.
+The following software is installed on machines in the Azure Pipelines **Windows Container 1803** (v$env:ImageVersion) pool.
 
 Components marked with **\*** have been upgraded since the previous version of the image.
 

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -86,6 +86,9 @@
         },
         {
             "type": "powershell",
+            "environment_vars": [
+                "ImageVersion={{user `image_version`}}"
+            ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Vs2017/Initialize-VM.ps1"
             ]

--- a/images/win/vs2019-Server2019-Azure.json
+++ b/images/win/vs2019-Server2019-Azure.json
@@ -87,6 +87,9 @@
         },
         {
             "type": "powershell",
+            "environment_vars": [
+                "ImageVersion={{user `image_version`}}"
+            ],
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Vs2019/Initialize-VM.ps1"
             ]


### PR DESCRIPTION
There's an image_version value now available in the Packer templates, these changes make it so that version is stamped on the readme files that get generated through the packer provisioners. That same value is saved in an environment variable in the machine and can be inspected during builds.