### PR TITLE
Add Android build-tools 29

### DIFF
--- a/images/linux/scripts/installers/1604/android.sh
+++ b/images/linux/scripts/installers/1604/android.sh
@@ -40,6 +40,8 @@ echo "y" | ${ANDROID_ROOT}/tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} \
     "platforms;android-17" \
     "platforms;android-15" \
     "platforms;android-10" \
+    "build-tools:29.0.2" \
+    "build-tools:29.0.0" \
     "build-tools;28.0.3" \
     "build-tools;28.0.2" \
     "build-tools;28.0.1" \
@@ -109,6 +111,8 @@ DocumentInstalledItem "Android SDK Platform 17"
 DocumentInstalledItem "Android SDK Platform 15"
 DocumentInstalledItem "Android SDK Platform 10"
 DocumentInstalledItem "Android SDK Patch Applier v4"
+DocumentInstalledItem "Android SDK Build-Tools 29.0.2"
+DocumentInstalledItem "Android SDK Build-Tools 29.0.0"
 DocumentInstalledItem "Android SDK Build-Tools 28.0.3"
 DocumentInstalledItem "Android SDK Build-Tools 28.0.2"
 DocumentInstalledItem "Android SDK Build-Tools 28.0.1"

--- a/images/linux/scripts/installers/1804/android.sh
+++ b/images/linux/scripts/installers/1804/android.sh
@@ -38,6 +38,8 @@ echo "y" | ${ANDROID_ROOT}/tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} \
     "platforms;android-21" \
     "platforms;android-19" \
     "platforms;android-17" \
+    "build-tools:29.0.2" \
+    "build-tools:29.0.0" \
     "build-tools;28.0.3" \
     "build-tools;28.0.2" \
     "build-tools;28.0.1" \
@@ -99,6 +101,8 @@ DocumentInstalledItem "Android SDK Platform 21"
 DocumentInstalledItem "Android SDK Platform 19"
 DocumentInstalledItem "Android SDK Platform 17"
 DocumentInstalledItem "Android SDK Patch Applier v4"
+DocumentInstalledItem "Android SDK Build-Tools 29.0.2"
+DocumentInstalledItem "Android SDK Build-Tools 29.0.0"
 DocumentInstalledItem "Android SDK Build-Tools 28.0.3"
 DocumentInstalledItem "Android SDK Build-Tools 28.0.2"
 DocumentInstalledItem "Android SDK Build-Tools 28.0.1"

--- a/images/win/scripts/Installers/Update-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Update-AndroidSDK.ps1
@@ -69,6 +69,8 @@ Push-Location -Path $sdk.FullName
     "platforms;android-22" `
     "platforms;android-21" `
     "platforms;android-19" `
+    "build-tools;29.0.2" `
+    "build-tools;29.0.0" `
     "build-tools;28.0.3" `
     "build-tools;28.0.2" `
     "build-tools;28.0.1" `


### PR DESCRIPTION
Missed build-tools in #1177 

Added 29.0.0 and 29.0.2 as per release notes: https://developer.android.com/studio/releases/build-tools