### PR TITLE
Update InstallHelpers.ps1

### DIFF
--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -81,3 +81,47 @@ function Install-EXE
         return -1
     }
 }
+
+function Install-VSIX
+{
+    Param
+    (
+        [String]$Url,
+        [String]$Name
+    )
+
+    $ReleaseInPath = 'Enterprise'
+    $exitCode = -1
+
+    try
+    {
+        Write-Host "Downloading $Name..."
+        $FilePath = "${env:Temp}\$Name"
+        Invoke-WebRequest -Uri $Url -OutFile $FilePath
+
+        $ArgumentList = ('/quiet', $FilePath)
+
+        Write-Host "Starting Install $Name..."
+
+        $filepath = "C:\Program Files (x86)\Microsoft Visual Studio\2019\$ReleaseInPath\Common7\IDE\VSIXInstaller.exe"        
+        $process = Start-Process -FilePath $filepath -ArgumentList $ArgumentList -Wait -PassThru
+        $exitCode = $process.ExitCode
+
+        if ($exitCode -eq 0 -or $exitCode -eq 3010)
+        {
+            Write-Host -Object 'Installation successful'
+            return $exitCode
+        }
+        else
+        {
+            Write-Host -Object "Non zero exit code returned by the installation process : $exitCode."
+            return $exitCode
+        }
+    }
+    catch
+    {
+        Write-Host -Object "Failed to install the Extension $Name"
+        Write-Host -Object $_.Exception.Message
+        return -1
+    }
+}


### PR DESCRIPTION
Install-VSIX
This makes it possible to install extensions.  SSDT is no longer installed in VS2019 but installed by using extension.
The following lines will install analysis services projects and report services projecsts

$exitcode = Install-VSIX -Name "Microsoft.DataTools.AnalysisServices.vsix"  -Url "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ProBITools/vsextensions/MicrosoftAnalysisServicesModelingProjects/2.8.17/vspackage" 
$exitcode = Install-VSIX -Name "Microsoft.DataTools.ReportingServices.vsix" -Url "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ProBITools/vsextensions/MicrosoftReportProjectsforVisualStudio/2.5.9/vspackage"