### PR TITLE
Document AWS CLI in Hosted Ubuntu 1604 readme

### DIFF
--- a/images/linux/Ubuntu1604-README.md
+++ b/images/linux/Ubuntu1604-README.md
@@ -3,6 +3,7 @@ The following software is installed on machines in the Hosted Ubuntu 1604 pool
 ***
 - 7-Zip 9.20
 - Ansible (ansible 2.8.3)
+- AWS CLI
 - AzCopy (azcopy 7.3.0-netcore)
 - Azure CLI (azure-cli                         2.0.70)
 - Azure CLI (azure-devops                      0.11.0)


### PR DESCRIPTION
https://github.com/microsoft/azure-pipelines-image-generation/pull/1167 introduced the AWS CLI (amongst others) into the Hosted Ubuntu 1604 and 1804 images.

This change was not documented, so this PR adds that information to the readme.

Unfortunately the PR implementing this change (https://github.com/microsoft/azure-pipelines-image-generation/pull/1167) didn't specify a version, so I'm unable to provide this information in the readme.