### PR TITLE
macos 1014 week 35 updates

### DIFF
--- a/images/macos/macos-10.14-Readme.md
+++ b/images/macos/macos-10.14-Readme.md
@@ -12,7 +12,7 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
 
 ## Operating System
 
-- OS X 10.14.6 (18G84) **Mojave**
+- OS X 10.14.6 (18G87) **Mojave**
 
 ## Installed Software
 
@@ -26,15 +26,15 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
 - NVM 0.33.11
 - NVM - Installed node versions:
 	v6.17.1
-	v8.16.0
-	v10.16.2
-	v12.8.0
+	v8.16.1
+	v10.16.3
+	v12.9.0
 - PowerShell 6.2.2
 - Python 2.7.16
 - Python 3.7.4
 - Ruby 2.6.3p62
 - .NET Core SDK 1.0.1 1.0.4 1.1.10 1.1.11 1.1.12 1.1.13 1.1.4 1.1.5 1.1.7 1.1.8 1.1.9 2.0.0 2.0.3 2.1.100 2.1.101 2.1.102 2.1.103 2.1.104 2.1.105 2.1.2 2.1.200 2.1.201 2.1.202 2.1.300 2.1.301 2.1.302 2.1.4 2.1.400 2.1.401 2.1.402 2.1.403 2.1.500 2.1.502 2.1.503 2.1.504 2.1.505 2.2.100 2.2.101 2.2.102 2.2.103 2.2.104 2.2.105
-- Go 1.12.7
+- Go 1.12.9
 
 
 ### Package Management
@@ -42,7 +42,7 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
 - Bundler 2.0.2
 - Carthage 0.33.0
 - CocoaPods 1.7.5
-- Homebrew 2.1.9
+- Homebrew 2.1.10
 - NPM 3.10.10
 - Yarn 1.17.3
 - NuGet 4.7.0.5148
@@ -52,12 +52,12 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
 ### Project Management
 
 - Apache Maven 3.6.1
-- Gradle 5.5.1
+- Gradle 5.6
 
 ### Utilities
 
 - curl 7.65.3 (libcurl/7.64.1 SecureTransport zlib/1.2.11)
-- Git 2.22.0
+- Git 2.23.0
 - Git LFS 2.8.0
 - GNU Wget 1.20.3
 - Subversion (SVN) 1.12.2
@@ -65,9 +65,9 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
 
 ### Tools
 
-- fastlane 2.128.1
+- fastlane 2.129.0
 - App Center CLI 1.2.2
-- Azure-CLI 2.0.70
+- Azure-CLI 2.0.71
 
 ### Pre-cached tools
 
@@ -83,13 +83,13 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
   - 2.3.8
   - 2.4.6
   - 2.5.5
-  - 2.6.2
+  - 2.6.3
 
 ### Xcode
 
 | Version                | Build   | Path                            |
 |------------------------|---------|---------------------------------|
-| 11_beta 5              | 11M382q | /Applications/Xcode_11.app      |
+| 11_beta 6              | 11M392q | /Applications/Xcode_11.app      |
 | 10.3                   | 10G8    | /Applications/Xcode_10.3.app    |
 | 10.2.1                 | 10E1001 | /Applications/Xcode_10.2.1.app  |
 | 10.2                   | 10E125  | /Applications/Xcode_10.2.app    |
@@ -256,6 +256,8 @@ xcversion simulators --install='iOS 8.4'
 | build-tools-28.0.2    | Android SDK Build-tools, Revision 28.0.2  |
 | build-tools-28.0.3    | Android SDK Build-tools, Revision 28.0.3  |
 | build-tools-29.0.0    | Android SDK Build-tools, Revision 29.0.0  |
+| build-tools-29.0.1    | Android SDK Build-tools, Revision 29.0.1  |
+| build-tools-29.0.2    | Android SDK Build-tools, Revision 29.0.2  |
 
 ### Utils
 
@@ -289,7 +291,7 @@ xcversion simulators --install='iOS 8.4'
 
 ### Visual Studio for Mac
 
-- 8.2.2.21
+- 8.2.4.17
 
 
 ### Mono


### PR DESCRIPTION


    System Version: macOS 10.14.6 (18G87)
    Xcode 11 beta 6 (11M392q)
    Xcode 10.3 set as default
    Git 2.23.0
    Homebrew 2.1.10
    fastlane 2.129.0
    Gradle 5.6
    azure-cli 2.0.71
    Go 1.12.9
    Node NVM (v8.16.1, v10.16.3, v12.9.0)
    macOS toolcache Ruby 2.6.3
    android build sdk 29.0.1, 29.0.2
    Visual Studio for Mac: 8.2.4.17

