### PR TITLE
Revert unifying linux/windows npm versions

### DIFF
--- a/images/win/scripts/Installers/Install-NodeLts.ps1
+++ b/images/win/scripts/Installers/Install-NodeLts.ps1
@@ -25,7 +25,6 @@ setx NPM_CONFIG_CACHE $CachePath /M
 $env:NPM_CONFIG_CACHE = $CachePath
 
 npm config set registry http://registry.npmjs.org/
-npm install -g npm
 
 npm install -g bower
 npm install -g cordova


### PR DESCRIPTION
Npm update was added to windows installers to unify the version installed with linux and windows. This overrode the already installed npm version packaged with nodelts.

Commit: https://github.com/microsoft/azure-pipelines-image-generation/commit/42a155dd6145a53416d79c45d9721f683e286187#diff-05e90063124f56972f7319f78d0b0db7