### PR TITLE
Revert unifying linux/windows npm versions

### DIFF
--- a/images/win/scripts/Installers/Install-NodeLts.ps1
+++ b/images/win/scripts/Installers/Install-NodeLts.ps1
@@ -25,7 +25,6 @@ setx NPM_CONFIG_CACHE $CachePath /M
 $env:NPM_CONFIG_CACHE = $CachePath
 
 npm config set registry http://registry.npmjs.org/
-npm install -g npm
 
 npm install -g bower
 npm install -g cordova


### PR DESCRIPTION
Cherry-pick from master to remove forced upgrade of npm that was leading to non-lts versions.