### PR TITLE
Configure java-tools.sh to fail if a command fails

### DIFF
--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -10,6 +10,8 @@ source $HELPER_SCRIPTS/document.sh
 
 DEFAULT_JDK_VERSION=8
 
+set -e
+
 # Install the Azul Systems Zulu JDKs
 # See https://www.azul.com/downloads/azure-only/zulu/
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9


### PR DESCRIPTION
We are seeing an issue where the Maven download is failing occasionally during CI runs.
Adding `set -e` will configure the whole script to fail if one the commands returns a nonzero exit code.
The script will already fail later on when it checks for Maven, but this will make the error clearer in the logs.

**Testing**
Ran this script as part of the Ubuntu 16 Packer build.  Tested success and failure.