### PR TITLE
Add Go 1.13 to Ubuntu 16.04, Ubuntu 18.04, VS2017, and VS2019

### DIFF
--- a/images/linux/scripts/installers/1604/go.sh
+++ b/images/linux/scripts/installers/1604/go.sh
@@ -33,5 +33,5 @@ function InstallGo () {
 InstallGo 1.9 1.9.7 false
 InstallGo 1.10 1.10.8 false
 InstallGo 1.11 1.11.12 false
-InstallGo 1.12 1.12.7 false
-InstallGo 1.13 1.13 true
+InstallGo 1.12 1.12.7 true
+InstallGo 1.13 1.13 false

--- a/images/linux/scripts/installers/1604/go.sh
+++ b/images/linux/scripts/installers/1604/go.sh
@@ -33,4 +33,5 @@ function InstallGo () {
 InstallGo 1.9 1.9.7 false
 InstallGo 1.10 1.10.8 false
 InstallGo 1.11 1.11.12 false
-InstallGo 1.12 1.12.7 true
+InstallGo 1.12 1.12.7 false
+InstallGo 1.13 1.13 true

--- a/images/linux/scripts/installers/1804/go.sh
+++ b/images/linux/scripts/installers/1804/go.sh
@@ -32,3 +32,4 @@ function InstallGo () {
 # Install Go versions
 InstallGo 1.11 1.11.12 false
 InstallGo 1.12 1.12.7 true
+InstallGo 1.13 1.13 false

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -285,7 +285,7 @@
         {
             "type": "powershell",
             "environment_vars": [
-                "GO_VERSIONS=1.9.7,1.10.8,1.11.12,1.12.7",
+                "GO_VERSIONS=1.9.7,1.10.8,1.11.12,1.12.7,1.13",
                 "GO_DEFAULT=1.12.7"
             ],
             "scripts":[
@@ -561,7 +561,7 @@
         {
             "type": "powershell",
             "environment_vars": [
-                "GO_VERSIONS=1.9.7,1.10.8,1.11.12,1.12.7",
+                "GO_VERSIONS=1.9.7,1.10.8,1.11.12,1.12.7,1.13",
                 "GO_DEFAULT=1.12.7"
             ],
             "scripts":[

--- a/images/win/vs2019-Server2019-Azure.json
+++ b/images/win/vs2019-Server2019-Azure.json
@@ -255,7 +255,7 @@
         {
             "type": "powershell",
             "environment_vars": [
-                "GO_VERSIONS=1.10.8,1.11.12,1.12.7",
+                "GO_VERSIONS=1.10.8,1.11.12,1.12.7,1.13",
                 "GO_DEFAULT=1.12.7"
             ],
             "scripts":[
@@ -531,7 +531,7 @@
         {
             "type": "powershell",
             "environment_vars": [
-                "GO_VERSIONS=1.10.8,1.11.12,1.12.7",
+                "GO_VERSIONS=1.10.8,1.11.12,1.12.7,1.13",
                 "GO_DEFAULT=1.12.7"
             ],
             "scripts":[


### PR DESCRIPTION
[go 1.13 was released](https://golang.org/doc/devel/release.html#go1.13) and it should be available in the agents