### PR TITLE
Cherry pick released readme files into master

### DIFF
--- a/images/linux/Ubuntu1604-README.md
+++ b/images/linux/Ubuntu1604-README.md
@@ -2,10 +2,10 @@
 The following software is installed on machines in the Hosted Ubuntu 1604 pool
 ***
 - 7-Zip 9.20
-- Ansible (ansible 2.8.3)
+- Ansible (ansible 2.8.4)
 - AzCopy (azcopy 7.3.0-netcore)
-- Azure CLI (azure-cli                         2.0.70)
-- Azure CLI (azure-devops                      0.11.0)
+- Azure CLI (azure-cli                         2.0.71)
+- Azure CLI (azure-devops                      0.12.0)
 - Basic CLI:
   - curl
   - dnsutils
@@ -29,6 +29,7 @@ The following software is installed on machines in the Hosted Ubuntu 1604 pool
   - wget
   - zip
   - tzdata
+- AWS CLI (aws-cli/1.16.221 Python/2.7.12 Linux/4.15.0-1055-azure botocore/1.12.211)
 - build-essential
 - Clang 6.0 (clang version 6.0.1-svn334776-1~exp1~20190309042730.123 (branches/release_60))
 - CMake (cmake version 3.12.4)
@@ -78,62 +79,63 @@ The following software is installed on machines in the Hosted Ubuntu 1604 pool
 - .NET Core SDK 2.2.104
 - .NET Core SDK 2.2.105
 - Erlang (Erlang (SMP,ASYNC_THREADS,HIPE) (BEAM) emulator version 10.4.4)
-- Firefox (Mozilla Firefox 68.0.1)
+- Firefox (Mozilla Firefox 68.0.2)
 - GNU C++ 7.4.0
-- Git (2.22.0)
+- Git (2.23.0)
 - Git Large File Storage (LFS) (2.8.0)
 - Go 1.9 (go version go1.9.7 linux/amd64)
 - Go 1.10 (go version go1.10.8 linux/amd64)
 - Go 1.11 (go version go1.11.12 linux/amd64)
 - Go 1.12 (go version go1.12.7 linux/amd64)
-- Google Chrome (Google Chrome 76.0.3809.87 )
+- Google Chrome (Google Chrome 76.0.3809.100 )
+- Google Cloud SDK (258.0.0)
 - Haskell (The Glorious Glasgow Haskell Compilation System, version 7.10.3)
-- Heroku (heroku/7.27.1 linux-x64 node-v11.14.0)
-- HHVM (HipHop VM 4.16.1 (rel))
+- Heroku (heroku/7.28.0 linux-x64 node-v11.14.0)
+- HHVM (HipHop VM 4.19.0 (rel))
 - ImageMagick
 - Azul Zulu OpenJDK (7) (openjdk version "1.7.0_232")
 - Azul Zulu OpenJDK (8) (openjdk version "1.8.0_222")
 - Azul Zulu OpenJDK (11) (openjdk version "11.0.4" 2019-07-16 LTS)
 - Azul Zulu OpenJDK (12) (openjdk version "12.0.2" 2019-07-16)
 - Ant (Apache Ant(TM) version 1.9.6 compiled on July 20 2018)
-- Gradle 5.5.1
+- Gradle 5.6
 - Maven (Apache Maven 3.6.1 (d66c9c0b3152b2e69ee9bac180bb8fcc8e6af555; 2019-04-04T19:00:29Z))
-- kubectl (Client Version: v1.15.1)
+- kubectl (Client Version: v1.15.3)
 - helm (Client: v2.14.3+g0e7f3b6)
 - Leiningen (Leiningen 2.9.1 on Java 1.8.0_222 OpenJDK 64-Bit Server VM)
 - Mercurial (Mercurial Distributed SCM (version 4.4.1))
 - Miniconda (conda 4.7.10)
-- Mono (Mono JIT compiler version 6.0.0.313 (tarball Sun Jul 14 09:59:19 UTC 2019))
+- Mono (Mono JIT compiler version 6.0.0.319 (tarball Mon Aug 12 23:49:12 UTC 2019))
 - MySQL (mysql  Ver 14.14 Distrib 5.7.27, for Linux (x86_64) using  EditLine wrapper)
 - MySQL Server (user:root password:root)
 - MS SQL Server Client Tools
-- Node.js (v10.16.1)
+- Node.js (v10.16.3)
 - Bower (1.8.8)
 - Grunt (grunt-cli v1.2.0)
 - Gulp (CLI version: 2.2.0
 Local version: Unknown)
-- n (5.0.1)
+- n (6.0.1)
 - Parcel (1.12.3)
 - TypeScript (Version 3.5.3)
-- Webpack (4.39.0)
-- Webpack CLI (3.3.6)
+- Webpack (4.39.2)
+- Webpack CLI (3.3.7)
 - Yarn (1.17.3)
 - PhantomJS (2.1.1)
-- PHP 5.6 (PHP 5.6.40-8+ubuntu16.04.1+deb.sury.org+1 (cli) )
-- PHP 7.0 (PHP 7.0.33-8+ubuntu16.04.1+deb.sury.org+1 (cli) (built: May 31 2019 11:34:07) ( NTS ))
-- PHP 7.1 (PHP 7.1.30-1+ubuntu16.04.1+deb.sury.org+1 (cli) (built: May 31 2019 11:43:14) ( NTS ))
-- PHP 7.2 (PHP 7.2.20-2+ubuntu16.04.1+deb.sury.org+1 (cli) (built: Jul 25 2019 11:42:36) ( NTS ))
-- PHP 7.3 (PHP 7.3.7-2+ubuntu16.04.1+deb.sury.org+1 (cli) (built: Jul 25 2019 11:44:40) ( NTS ))
-- Composer  (Composer version 1.8.6 2019-06-11 15:03:05)
+- PHP 5.6 (PHP 5.6.40-10+ubuntu16.04.1+deb.sury.org+1 (cli) )
+- PHP 7.0 (PHP 7.0.33-10+ubuntu16.04.1+deb.sury.org+1 (cli) (built: Aug  7 2019 09:50:44) ( NTS ))
+- PHP 7.1 (PHP 7.1.31-1+ubuntu16.04.1+deb.sury.org+1 (cli) (built: Aug  7 2019 10:22:48) ( NTS ))
+- PHP 7.2 (PHP 7.2.21-1+ubuntu16.04.1+deb.sury.org+1 (cli) (built: Aug  7 2019 09:53:30) ( NTS ))
+- PHP 7.3 (PHP 7.3.8-1+ubuntu16.04.1+deb.sury.org+1 (cli) (built: Aug  7 2019 09:51:47) ( NTS ))
+- Composer  (Composer version 1.9.0 2019-08-02 20:55:32)
 - PHPUnit (PHPUnit 7.5.14 by Sebastian Bergmann and contributors.)
 - Pollinate
 - Powershell (PowerShell 6.2.2)
 - rustup (1.18.3)
-- rust (1.36.0)
-- cargo (1.36.0)
-- rustfmt (1.2.2-stable)
+- rust (1.37.0)
+- cargo (1.37.0)
+- rustfmt (1.3.0-stable)
 - clippy (0.0.212)
-- rustdoc (1.36.0)
+- rustdoc (1.37.0)
 - bindgen (execute
 the
 0.51.0)
@@ -142,7 +144,8 @@ the
 - Sphinx Open Source Search Server
 - Subversion (svn, version 1.9.3 (r1718519))
 - Terraform (Terraform v0.12.6)
-- Vcpkg 2019.07.18-unknownhash
+- Vcpkg 2019.07.19-unknownhash
+- Zeit Now CLI (16.1.1)
 - Google Repository 58
 - Google Play services 49
 - Google APIs 24
@@ -201,15 +204,15 @@ the
 - Az Module (1.0.0)
 - Az Module (1.6.0)
 - Cached container images
-  - jekyll/builder:latest (Digest: sha256:f4746468ab68c88643fed4e41683b9ffe671a3f4ec8e2d3ed99b4f257eb7af40)
-  - node:12 (Digest: sha256:4bb14d2108495d565050a50ed624874dbbb17552ec4adb6f396f9edcdcbcd8d4)
-  - node:12-alpine (Digest: sha256:300e3d2c19067c1aec9d9b2bd3acbd43d53797a5836d70a23e437a5634bcd33a)
-  - node:10 (Digest: sha256:523f767f8907f002316d3334bdb9d1154c7c6f6157c7aed3de5305726a963616)
+  - jekyll/builder:latest (Digest: sha256:6d36dcd52b3eafa6b81360d7e9e4f6676c34997d9f8feb2ec3a8f773f3bbdb85)
+  - node:10 (Digest: sha256:8eab6272219cb2eef3106a2b2c72ba85627008ebe5f1471dabc76c10e688ad59)
+  - node:10-alpine (Digest: sha256:abd8fa1df6dc74213878a96d9c38601ffbb9deb80b0030e758a690699022d639)
+  - node:12 (Digest: sha256:2eb5b7ee06215cda1c697c178978c51367b78ee3992a058f37b73616521fc104)
+  - node:12-alpine (Digest: sha256:9b4ef9aae0d8c9c7a4dbbff596acf98e7d7e6a1843ed7d751fabfc2d4680a5d5)
+  - buildpack-deps:stretch (Digest: sha256:b2cf19b81f3a01d1ee58c7731b7d5c7cde2abe1f081df17458daf571e16873a5)
+  - debian:9 (Digest: sha256:94a5c04481bb50a4f34ebbb105e39388700202a6e34cb41b9b9afdaca854567c)
+  - debian:8 (Digest: sha256:c72197393c39c05e19c8ef3388af53a6daa2baa0bed6111b09e40a298d9f7eca)
   - alpine:3.10 (Digest: sha256:6a92cd1fcdc8d8cdec60f33dda4db2cb1fcdcacf3410a8e05b3741f44a9b5998)
-  - buildpack-deps:stretch (Digest: sha256:95988ea7791e9bb6b66abd889b31cba5e26c2756705683b58287cbe1fb158fcf)
-  - debian:9 (Digest: sha256:397b2157a9ea8d7f16c613aded70284292106e8b813fb1ed5de8a8785310a26a)
-  - debian:8 (Digest: sha256:a8ae3c5129fb2e10a62b5c059a24308831508c44018c24ccda2e4fc6fd7cdda7)
-  - node:10-alpine (Digest: sha256:07897ec27318d8e43cfc6b1762e7a28ed01479ba4927aca0cdff53c1de9ea6fd)
   - alpine:3.9 (Digest: sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a)
   - alpine:3.7 (Digest: sha256:8421d9a84432575381bfabd248f1eb56f3aa21d9d7cd2511583c68c9b7511d10)
   - alpine:3.8 (Digest: sha256:04696b491e0cc3c58a75bace8941c14c924b9f313b03ce5029ebbc040ed9dcd9)
@@ -224,7 +227,7 @@ the
   - Ruby 2.3.7
   - Ruby 2.4.6
   - Ruby 2.5.5
-  - Ruby 2.6.2
+  - Ruby 2.6.3
 - Python (Python 2.7.12)
 - pip (pip 8.1.1 from /usr/lib/python2.7/dist-packages (python 2.7))
 - Python3 (Python 3.5.2)

--- a/images/win/Vs2017-Server2016-Readme.md
+++ b/images/win/Vs2017-Server2016-Readme.md
@@ -25,20 +25,21 @@ _Environment:_
 
 ## Powershell Core
 
-_Version:_ 6.2.2<br/>
+_Version:_ 6.2.2
+<br/>
 
 ## Docker images
 
 The following container images have been cached:
-* mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2016 (Digest: sha256:82966793552b6c511fca7a29cad6df06279691e51b720a424fe49bce937782bd)
-* mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2016 (Digest: sha256:f335e28bc958ceb068c353ff01d76d503a878996e11228dde3c3637676bd1ae2)
-* mcr.microsoft.com/windows/servercore:ltsc2016 (Digest: sha256:26db04f4287d5809cda597c2fd05a7b14fe5d8018e09217073310bb2cabcc61d)
+* mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2016 (Digest: sha256:df1c519aa1ba178604aa64576e3376b480bea74a0dddca32b251de5633f88b6a)
+* mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2016 (Digest: sha256:2c6ea4a26a9db53660b653fe3b5e76a2deed5c58b841b28546b29d8d7a8ba41f)
+* mcr.microsoft.com/windows/servercore:ltsc2016 (Digest: sha256:a8bc031f38ad457c3a04fcf72c7773014c6960978299c3dfe3e1c4d133f35190)
 * microsoft/aspnetcore-build:1.0-2.0 (Digest: sha256:9ecc7c5a8a7a11dca5f08c860165646cb30d084606360a3a72b9cbe447241c0c)
 * mcr.microsoft.com/windows/nanoserver:10.0.14393.953 (Digest: sha256:fc60bd5ae0e61b334ce1cf1bcbf20c10c36b4c5482a01da319c9c989f9e6e268)
 
 ## Visual Studio 2017 Enterprise
 
-_Version:_ VisualStudio/15.9.14+28307.770<br/>
+_Version:_ VisualStudio/15.9.15+28307.812<br/>
 _Location:_ C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise
 
 The following workloads including required and recommended components are installed with Visual Studio 2017:
@@ -276,6 +277,10 @@ _Location:_ C:\Program Files (x86)\Android\android-sdk\build-tools\19.1.0
 
 ## Android SDK Platforms
 
+#### 10 (API 29)
+
+_Location:_ C:\Program Files (x86)\Android\android-sdk\platforms\android-29
+
 #### 9 (API 28)
 
 _Location:_ C:\Program Files (x86)\Android\android-sdk\platforms\android-28
@@ -317,7 +322,8 @@ _Location:_ C:\Program Files (x86)\Android\android-sdk\platforms\android-19
 
 #### 2.1.0
 
-This version is installed and is available via Get-Module -ListAvailable
+This version is installed and is available via Get-Module -ListAvailable
+
 #### 3.8.0
 
 This version is saved but not installed
@@ -346,7 +352,7 @@ _Description:_ .NET has been configured to use TLS 1.2 by default
 
 ## Azure CLI
 
-_Version:_ 2.0.70
+_Version:_ 2.0.71
 _Environment:_
 * PATH: contains location of az.cmd
 
@@ -366,7 +372,7 @@ _Version:_ 2.7.13 (x86)<br/>_Version:_ 3.5.3 (x86)<br/><br/>
 
 ## Ruby
 
-_Version:_ 2.4.5 (x64)<br/>_Version:_ 2.5.3 (x64)<br/>_Version:_ 2.6.1 (x64)<br/><br/>
+_Version:_ 2.4.6 (x64)<br/>_Version:_ 2.5.5 (x64)<br/>_Version:_ 2.6.3 (x64)<br/><br/>
 > Note: These versions of Ruby are available through the [Use Ruby Version](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/use-ruby-version) task.
 
 ## Python (64 bit)
@@ -428,22 +434,22 @@ _Environment:_
 
 ## PHP (x64)
 
-#### 7.3.7
+#### 7.3.8
 
 _Environment:_
-* PATH: contains the location of php.exe version 7.3.7
-* PHPROOT: root directory of the PHP 7.3.7 installation
+* PATH: contains the location of php.exe version 7.3.8
+* PHPROOT: root directory of the PHP 7.3.8 installation
 
 ## Ruby (x64)
 
-#### 2.5.3p105
+#### 2.5.5p157
 _Environment:_
-* Location: C:\hostedtoolcache\windows\Ruby\2.5.3\x64\bin
-* PATH: contains the location of ruby.exe version 2.5.3p105
+* Location: C:\hostedtoolcache\windows\Ruby\2.5.5\x64\bin
+* PATH: contains the location of ruby.exe version 2.5.5p157
 
 ## Rust (64-bit)
 
-#### 1.36.0
+#### 1.37.0
 _Location:_ C:\Rust\.cargo\bin
 _Environment:_
 * PATH: contains the location of rustc.exe
@@ -457,12 +463,12 @@ _Environment:_
 ## Google Chrome
 
 _version:_
-75.0.3770.142
+76.0.3809.100
 
 ## Mozilla Firefox
 
 _version:_
-68.0.1
+68.0.2
 
 ## Selenium Web Drivers
 
@@ -470,7 +476,7 @@ _version:_
 #### Chrome Driver
 
 _version:_
-75.0.3770.140
+76.0.3809.68
 
 _Environment:_
 * ChromeWebDriver: location of chromedriver.exe
@@ -494,7 +500,7 @@ _Environment:_
 
 ## Node.js
 
-_Version:_ 10.16.1<br/>
+_Version:_ 10.16.3<br/>
 _Architecture:_ x64<br/>
 _Environment:_
 * PATH: contains location of node.exe<br/>
@@ -544,13 +550,13 @@ _Environment:_
 
 ## Gradle
 
-_Version:_ 5.5.1<br/>
+_Version:_ 5.6<br/>
 _Environment:_
 * PATH: contains location of gradle
 
 ## Cmake
 
-_Version:_ 3.15.1<br/>
+_Version:_ 3.15.2<br/>
 _Environment:_
 * PATH: contains location of cmake.exe
 
@@ -715,7 +721,7 @@ _Version:_ v5.26.2<br/>
 
 ## GitVersion
 
-_Version:_ 5.0.0.0<br/>
+_Version:_ 5.0.1.0<br/>
 
 ## OpenSSL
 
@@ -727,7 +733,7 @@ _Version:_ 6.46.0<br/>
 
 ## Vcpkg
 
-_Version:_ 2019.07.18-nohash<br/>
+_Version:_ 2019.08.16-nohash<br/>
 _Environment:_
 * PATH: contains location of the vcpkg directory
 * VCPKG_INSTALLATION_ROOT: root directory of the vcpkg installation

--- a/images/win/WindowsContainer1803-Readme.md
+++ b/images/win/WindowsContainer1803-Readme.md
@@ -1,6 +1,6 @@
 # Azure Pipelines Windows Container 1803 image
 
-The following software is installed on machines in the Azure Pipelines **Windows Container 1803** pool.
+The following software is installed on machines in the Azure Pipelines **Windows Container 1803** (v157.1) pool.
 
 Components marked with **\*** have been upgraded since the previous version of the image.
 
@@ -30,17 +30,17 @@ _Version:_ 6.2.2<br/>
 ## Docker images
 
 The following container images have been cached:
-* microsoft/dotnet-framework:4.7.2-sdk-windowsservercore-1803 (Digest: sha256:af2ba65cf68152c7b745e3253137ece34ead87df9e451755ae8226c1acacb38a)
-* microsoft/aspnet:4.7.2-windowsservercore-1803 (Digest: sha256:42bc7ff1ac8872933a0db8d1ae2a3a26f25c27e30186cf546a72ff475d3c7019)
-* microsoft/windowsservercore:1803 (Digest: sha256:4374dbc78737bfec459fe6e2047466faa7c21a03aec362ce61735692ed54e598)
+* microsoft/aspnet:4.7.2-windowsservercore-1803 (Digest: sha256:3f9cc564b911978530fa0326a3fda977e371ee4ef7c4170e305a664adad65faa)
+* microsoft/dotnet-framework:4.7.2-sdk-windowsservercore-1803 (Digest: sha256:342f58c3440bdf06da14b1bb391b3341691123310067046855392dfa8500c78d)
+* microsoft/nanoserver:1803 (Digest: sha256:19b76c64bce0f16f7e79517132fc66e3b8c4f6ba20b6c2b53fbc9d28b272e876)
+* microsoft/windowsservercore:1803 (Digest: sha256:38ee28ebce7f1dda2af019138eb5287f047b1280a2d755ec6f963d4e8abec115)
 * mcr.microsoft.com/windows/servercore:1803 (Digest: sha256:4374dbc78737bfec459fe6e2047466faa7c21a03aec362ce61735692ed54e598)
-* microsoft/nanoserver:1803 (Digest: sha256:bc5c1878a69c4538d55bc74e50b7dbafafff1a373120e624e8bad646a0a505dc)
 * mcr.microsoft.com/windows/nanoserver:1803 (Digest: sha256:bc5c1878a69c4538d55bc74e50b7dbafafff1a373120e624e8bad646a0a505dc)
 * microsoft/aspnetcore-build:2.0-nanoserver-1803 (Digest: sha256:82ad5218bb554d0b44ca54c21aba78b5ae10b92cead389d71328614b99fc47af)
 
 ## Node.js
 
-_Version:_ 10.16.1<br/>
+_Version:_ 10.16.3<br/>
 _Architecture:_ x64<br/>
 _Environment:_
 * PATH: contains location of node.exe<br/>
@@ -53,7 +53,7 @@ _Environment:_
 
 ## npm
 
-_Version:_ 6.10.2<br/>
+_Version:_ 6.10.3<br/>
 _Environment:_
 * PATH: contains location of npm.cmd
 


### PR DESCRIPTION
This includes VS2017, Ubuntu16, and WinCon only since VS2019 image for 157 version has been regenerated and is currently being tested.