### PR TITLE
Decreasing disk size for Ubuntu images to support Ephemeral.

### DIFF
--- a/images/linux/ubuntu1604.json
+++ b/images/linux/ubuntu1604.json
@@ -43,7 +43,7 @@
             "image_publisher": "Canonical",
             "image_offer": "UbuntuServer",
             "image_sku": "16.04-LTS",
-            "os_disk_size_gb": "128"
+            "os_disk_size_gb": "86"
         }
     ],
     "provisioners": [

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -43,7 +43,7 @@
             "image_publisher": "Canonical",
             "image_offer": "UbuntuServer",
             "image_sku": "18.04-LTS",
-            "os_disk_size_gb": "128"
+            "os_disk_size_gb": "86"
         }
     ],
     "provisioners": [


### PR DESCRIPTION
This is needed to support running Ubuntu images on Ephemeral disks in Azure.