### PR TITLE
Fix Android install scripts for ubuntu.

### DIFF
--- a/images/linux/scripts/installers/1604/android.sh
+++ b/images/linux/scripts/installers/1604/android.sh
@@ -10,9 +10,9 @@ source $HELPER_SCRIPTS/document.sh
 source $HELPER_SCRIPTS/apt.sh
 
 # Set env variable for SDK Root (https://developer.android.com/studio/command-line/variables)
-ANDROID_ROOT=/usr/local/lib/android
-ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
-echo "ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT}" | tee -a /etc/environment
+    ANDROID_ROOT=/usr/local/lib/android
+    ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
+    echo "ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT}" | tee -a /etc/environment
 
 # ANDROID_HOME is deprecated, but older versions of Gradle rely on it
 echo "ANDROID_HOME=${ANDROID_SDK_ROOT}" | tee -a /etc/environment
@@ -40,8 +40,8 @@ echo "y" | ${ANDROID_ROOT}/tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} \
     "platforms;android-17" \
     "platforms;android-15" \
     "platforms;android-10" \
-    "build-tools:29.0.2" \
-    "build-tools:29.0.0" \
+    "build-tools;29.0.2" \
+    "build-tools;29.0.0" \
     "build-tools;28.0.3" \
     "build-tools;28.0.2" \
     "build-tools;28.0.1" \

--- a/images/linux/scripts/installers/1804/android.sh
+++ b/images/linux/scripts/installers/1804/android.sh
@@ -38,8 +38,8 @@ echo "y" | ${ANDROID_ROOT}/tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} \
     "platforms;android-21" \
     "platforms;android-19" \
     "platforms;android-17" \
-    "build-tools:29.0.2" \
-    "build-tools:29.0.0" \
+    "build-tools;29.0.2" \
+    "build-tools;29.0.0" \
     "build-tools;28.0.3" \
     "build-tools;28.0.2" \
     "build-tools;28.0.1" \


### PR DESCRIPTION
The scripts had : where they should have ; in the updates to include Android SDK and build tools 29.