### PR TITLE
Revert "updatd script to install all dotnet sdks from releases-index.json"

### DIFF
--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -10,6 +10,14 @@ New-Item -Path C:\Temp -Force -ItemType Directory
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor "Tls12"
 
+Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases.json' -UseBasicParsing -OutFile 'dotnet-releases.json'
+$dotnetReleases = Get-Content -Path 'dotnet-releases.json' | ConvertFrom-Json
+
+#Filtering dotnet sdk and runtime versions which does not have "-" in their name, based on naming pattern they are either preview or rc versions
+$dotnetReleases = $dotnetReleases | Where-Object {!$_."version-sdk".Contains('-') } | Sort-Object {[Version] $_."version-sdk"}
+
+Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -UseBasicParsing -OutFile 'dotnet-install.ps1'
+
 $templates = @(
     'console',
     'mstest',
@@ -18,17 +26,14 @@ $templates = @(
     'webapi'
 )
 
-function InstallSDKVersion (
-    $sdkVersion
-)
-{
-    if (!(Test-Path -Path "C:\Program Files\dotnet\sdk\$sdkVersion"))
-    {
+$dotnetReleases | ForEach-Object {
+    $release = $_
+    $sdkVersion = $release.'version-sdk'
+    if(!(Test-Path -Path "C:\Program Files\dotnet\sdk\$sdkVersion")) {
         Write-Host "Installing dotnet $sdkVersion"
         .\dotnet-install.ps1 -Architecture x64 -Version $sdkVersion -InstallDir $(Join-Path -Path $env:ProgramFiles -ChildPath 'dotnet')
     }
-    else
-    {
+    else {
         Write-Host "Sdk version $sdkVersion already installed"
     }
 
@@ -45,68 +50,15 @@ function InstallSDKVersion (
     }
 }
 
-function InstallAllValidSdks()
-{
-    Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases-index.json' -UseBasicParsing -OutFile 'releases-index.json'
-    $dotnetChannels = Get-Content -Path 'releases-index.json' | ConvertFrom-Json
-
-    # Consider all channels except preview/eol channels.
-    # Sort the channels in ascending order
-    $dotnetChannels = $dotnetChannels.'releases-index' | Where-Object { !$_."support-phase".Equals('preview') -and !$_."support-phase".Equals('eol') -and $_."channel-version" -lt "3.0" } | Sort-Object { [Version] $_."channel-version" }
-
-    # Download installation script.
-    Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -UseBasicParsing -OutFile 'dotnet-install.ps1'
-
-    ForEach ($dotnetChannel in $dotnetChannels)
-    {
-        $channelVersion = $dotnetChannel.'channel-version';
-        Invoke-WebRequest -Uri $dotnetChannel.'releases.json' -UseBasicParsing -OutFile "releases-$channelVersion.json"
-        $currentReleases = Get-Content -Path "releases-$channelVersion.json" | ConvertFrom-Json
-        # filtering out the preview/rc releases
-        $currentReleases = $currentReleases.'releases' | Where-Object { !$_.'release-version'.Contains('-') } | Sort-Object { [Version] $_.'release-version' }
-        ForEach ($release in $currentReleases)
-        {
-            if ($release.'sdks'.Count -gt 0)
-            {
-                Write-Host 'Found sdks property in release: ' + $release.'release-version' + 'with sdks count: ' + $release.'sdks'.Count
-
-
-                # Remove duplicate entries & preview/rc version from download list
-                # Sort the sdks on version
-                $sdks = @($release.'sdk');
-                $sdks += $release.'sdks' | Where-Object { !$_.'version'.Contains('-') -and !$_.'version'.Equals($release.'sdk'.'version') }
-                $sdks = $sdks | Sort-Object { [Version] $_.'version' }
-
-                $sdks.Contains($release.'sdk')
-                ForEach ($sdk in $sdks)
-                {
-                    InstallSDKVersion -sdkVersion $sdk.'version'
-                }
-            }
-            elseif (!$release.'sdk'.'version'.Contains('-'))
-            {
-                $sdkVersion = $release.'sdk'.'version'
-                InstallSDKVersion -sdkVersion $sdkVersion
-            }
-        }
-    }
-}
-
-function RunPostInstallationSteps()
-{
-    Add-MachinePathItem "C:\Program Files\dotnet"
-    # Run script at startup for all users
-    $cmdDotNetPath = @"
+Add-MachinePathItem "C:\Program Files\dotnet"
+# Run script at startup for all users
+$cmdDotNetPath = @"
 @echo off
 SETX PATH "%USERPROFILE%\.dotnet\tools;%PATH%"
 "@
 
-    $cmdPath = "C:\Program Files\dotnet\userpath.bat"
-    $cmdDotNetPath | Out-File -Encoding ascii -FilePath $cmdPath
+$cmdPath = "C:\Program Files\dotnet\userpath.bat"
+$cmdDotNetPath | Out-File -Encoding ascii -FilePath $cmdPath
 
-    # Update Run key to run a script at logon
-    Set-ItemProperty -Path "HKLM:\Software\Microsoft\Windows\CurrentVersion\Run" -Name "DOTNETUSERPATH" -Value $cmdPath
-}
-
-InstallAllValidSdks
-RunPostInstallationSteps
+# Update Run key to run a script at logon
+Set-ItemProperty -Path "HKLM:\Software\Microsoft\Windows\CurrentVersion\Run" -Name "DOTNETUSERPATH" -Value $cmdPath

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -153,12 +153,6 @@
         },
         {
             "type": "powershell",
-            "scripts":[
-                "{{ template_dir }}/scripts/Installers/Install-DotnetSDK.ps1"
-            ]
-        },
-        {
-            "type": "powershell",
             "valid_exit_codes": [
                 0,
                 3010
@@ -221,12 +215,6 @@
         {
             "type": "windows-restart",
             "restart_timeout": "30m"
-        },
-        {
-            "type": "powershell",
-            "scripts":[
-                "{{ template_dir }}/scripts/Installers/Validate-DotnetSDK.ps1"
-            ]
         },
         {
             "type": "powershell",
@@ -406,6 +394,12 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-SQLPowerShellTools.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-DotnetSDK.ps1"
             ]
         },
         {
@@ -648,6 +642,12 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-DACFx.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-DotnetSDK.ps1"
             ]
         },
         {

--- a/images/win/vs2019-Server2019-Azure.json
+++ b/images/win/vs2019-Server2019-Azure.json
@@ -156,12 +156,6 @@
         },
         {
             "type": "powershell",
-            "scripts":[
-                "{{ template_dir }}/scripts/Installers/Install-DotnetSDK.ps1"
-            ]
-        },
-        {
-            "type": "powershell",
             "valid_exit_codes": [
                 0,
                 3010
@@ -197,12 +191,6 @@
         {
             "type": "windows-restart",
             "restart_timeout": "10m"
-        },
-        {
-            "type": "powershell",
-            "scripts":[
-                "{{ template_dir }}/scripts/Installers/Validate-DotnetSDK.ps1"
-            ]
         },
         {
             "type": "powershell",
@@ -376,6 +364,12 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-SQLPowerShellTools.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-DotnetSDK.ps1"
             ]
         },
         {
@@ -618,6 +612,12 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-DACFx.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-DotnetSDK.ps1"
             ]
         },
         {


### PR DESCRIPTION
This is an issue for Run-Antivirus fails on WS2019-VS2019 #1235. While investigating it, I found an error related to notnetsdk
```
2019-09-13T06:12:15.0438265Z  mmsprodwcus0        vhd: At C:\Windows\Temp\script-5d7b2519-5fb9-4931-4674-ba9f32f8e9ea.ps1:80 char:17
2019-09-13T06:12:15.0448894Z  mmsprodwcus0        vhd: Found sdks property in release:  + 2.1.801 + with sdks count:  + 1
2019-09-13T06:12:15.0456959Z  mmsprodwcus0        vhd: Installing dotnet 2.1.801
2019-09-13T06:12:15.0462329Z  mmsprodwcus0        vhd: +                 $sdks.Contains($release.'sdk')
2019-09-13T06:12:15.0468774Z  mmsprodwcus0        vhd: dotnet-install: Downloading link: https://dotnetcli.azureedge.net/dotnet/Sdk/2.1.801/dotnet-sdk-2.1.801-win-x64.zip
2019-09-13T06:12:15.0474745Z  mmsprodwcus0        vhd: +                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2019-09-13T06:12:15.0481469Z  mmsprodwcus0        vhd:     + CategoryInfo          : InvalidOperation: (Contains:String) [], RuntimeException
2019-09-13T06:12:15.0489957Z  mmsprodwcus0        vhd:     + FullyQualifiedErrorId : MethodNotFound
2019-09-13T06:12:15.0499355Z  mmsprodwcus0        vhd:
```
The vs2019 CI build start to fail from Sep 6th
https://dev.azure.com/mseng/AzureDevOps/_build?definitionId=8922&_a=summary
So revert the changes for testing.
@hiyadav