### PR TITLE
Newer Haskell build env with multiple ghc and cabal versions

### DIFF
--- a/images/linux/scripts/installers/haskell.sh
+++ b/images/linux/scripts/installers/haskell.sh
@@ -9,15 +9,57 @@
 source $HELPER_SCRIPTS/document.sh
 source $HELPER_SCRIPTS/apt.sh
 
-# Install haskell-platform
-apt-get install -y haskell-platform
+# Install Herbert V. Riedel's PPA for managing multiple version of ghc on ubuntu.
+# https://launchpad.net/~hvr/+archive/ubuntu/ghc
+apt-get install -y software-properties-common
+add-apt-repository -y ppa:hvr/ghc
+apt-get update
+
+# Install various versions of ghc and cabal
+apt-get install -y \
+    ghc-8.0.2 \
+    ghc-8.2.2 \
+    ghc-8.4.4 \
+    ghc-8.6.2 \
+    ghc-8.6.3 \
+    ghc-8.6.4 \
+    ghc-8.6.5 \
+    ghc-8.8.1 \
+    cabal-install-2.0 \
+    cabal-install-2.2 \
+    cabal-install-2.4 \
+    cabal-install-3.0
+
+# Install haskell stack, pinned to v2.1.3
+curl -sSL https://raw.githubusercontent.com/commercialhaskell/stack/v2.1.3/etc/scripts/get-stack.sh | sh
 
 # Run tests to determine that the software installed as expected
 echo "Testing to make sure that script performed as expected, and basic scenarios work"
-if ! command -v ghc; then
+# Check all ghc versions
+for version in 8.0.2 8.2.2 8.4.4 8.6.2 8.6.3 8.6.4 8.6.5 8.8.1; do
+    if ! command -v /opt/ghc/$version/bin/ghc; then
+        echo "ghc $version was not installed"
+        exit 1
+    fi
+done
+# Check all cabal versions
+for version in 2.0 2.2 2.4 3.0; do
+    if ! command -v /opt/cabal/$version/bin/cabal; then
+        echo "cabal $version was not installed"
+        exit 1
+    fi
+done
+# Check stack
+if ! command -v stack; then
     exit 1
 fi
 
 # Document what was added to the image
 echo "Lastly, documenting what we added to the metadata file"
-DocumentInstalledItem "Haskell ($(ghc --version))"
+for version in 2.0 2.2 2.4 3.0; do
+    DocumentInstalledItem "Haskell Cabal ($(/opt/cabal/$version/bin/cabal --version))"
+done
+for version in 8.0.2 8.2.2 8.4.4 8.6.2 8.6.3 8.6.4 8.6.5 8.8.1; do
+    DocumentInstalledItem "GHC ($(/opt/ghc/$version/bin/ghc --version))"
+done
+DocumentInstalledItem "Haskell Stack ($(stack --version))"


### PR DESCRIPTION
Proposes some changes to the Haskell build environment to enable modern Haskell development and matrix builds against different versions of ghc and cabal.

Right now, Haskell is supported, but the tooling installed by `apt-get install haskell-platform` is a bit dated making it hard to build Haskell projects and very difficult to do things like build against multiple versions of ghc. You can work around it by using docker, but it's often prohibitively slow.

I've attempted to capture both stack and cabal based builds and the recommended approach for targeting different versions of the compiler is to manipulate `PATH` as necessary. I picked a number of significant versions, but I'm sure there are opinions here.

I didn't find a great way within this project to test this kind of thing locally, so would love some advice there. I've validated the basic steps here by doing `docker run -it --rm ubuntu:18.04 bash` and then running parts of the `haskell.sh` script in that container. 

*👋 First time contributor 😄. I did read that opening an issue first is recommended, but I think the diff here does a good job representing the meat of the discussion and gives us some specifics to talk about. 100% open to conversation here or even not doing this at all!*

cc @kaylangan @robrix @patrickt