### PR TITLE
Fix wait-process that's failing after latest VS2019 update.

### DIFF
--- a/images/win/scripts/Installers/Vs2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Vs2019/Install-VS2019.ps1
@@ -159,7 +159,7 @@ $version = $catalog.info.id
 Write-Host "Visual Studio version" $version "installed"
 
 # Initialize Visual Studio Experimental Instance
-&"C:\Program Files (x86)\Microsoft Visual Studio\2019\$ReleaseInPath\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings /Command File.Exit | Wait-Process
+&"C:\Program Files (x86)\Microsoft Visual Studio\2019\$ReleaseInPath\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings /Command File.Exit
 
 # Updating content of MachineState.json file to disable autoupdate of VSIX extensions
 $newContent = '{"Extensions":[{"Key":"1e906ff5-9da8-4091-a299-5c253c55fdc9","Value":{"ShouldAutoUpdate":false}},{"Key":"Microsoft.VisualStudio.Web.AzureFunctions","Value":{"ShouldAutoUpdate":false}}],"ShouldAutoUpdate":false,"ShouldCheckForUpdates":false}'


### PR DESCRIPTION
Latest image generation processes for VS2019 fail with:
```2019-09-24T03:39:50.0478617Z  mmsprodwcus0        vhd: Wait-Process : The input object cannot be bound to any parameters for the command either because the command does not
2019-09-24T03:39:50.0486223Z !mmsprodwcus0    2019/09/24 03:39:50 packer.exe: 2019/09/24 03:39:50 [INFO] 973 bytes written for 'stdout'
2019-09-24T03:39:50.0552619Z !mmsprodwcus0    2019/09/24 03:39:50 packer.exe: 2019/09/24 03:39:50 [INFO] 0 bytes written for 'stderr'
2019-09-24T03:39:50.0553066Z !mmsprodwcus0    2019/09/24 03:39:50 packer.exe: 2019/09/24 03:39:50 [INFO] RPC client: Communicator ended with: 1
2019-09-24T03:39:50.0554290Z  mmsprodwcus0        vhd: take pipeline input or the input and its properties do not match any of the parameters that take pipeline input.
2019-09-24T03:39:50.0554454Z  mmsprodwcus0        vhd: At C:\Windows\Temp\script-5d897900-d6df-df06-3c2a-efdf408d36ae.ps1:162 char:165
2019-09-24T03:39:50.0554545Z  mmsprodwcus0        vhd: + ... p /ResetSettings General.vssettings /Command File.Exit | Wait-Process
2019-09-24T03:39:50.0555192Z  mmsprodwcus0        vhd: +                                                              ~~~~~~~~~~~~
2019-09-24T03:39:50.0555297Z  mmsprodwcus0        vhd:     + CategoryInfo          : InvalidArgument: (Devhub Core CLR... Microsoft Corp:PSObject) [Wait-Process], ParameterB
2019-09-24T03:39:50.0555377Z  mmsprodwcus0        vhd:    indingException
2019-09-24T03:39:50.0555518Z  mmsprodwcus0        vhd:     + FullyQualifiedErrorId : InputObjectNotBound,Microsoft.PowerShell.Commands.WaitProcessCommand
2019-09-24T03:39:50.0556321Z  mmsprodwcus0        vhd:
2019-09-24T03:39:50.0564970Z !mmsprodwcus0    2019/09/24 03:39:50 [INFO] (telemetry) ending powershell```

Modifying syntax to attempt to fix issue.