### PR TITLE
Wait for windows defender to be running

### DIFF
--- a/images/win/scripts/Installers/Vs2019/Run-Antivirus.ps1
+++ b/images/win/scripts/Installers/Vs2019/Run-Antivirus.ps1
@@ -5,6 +5,10 @@
 ##         Run right after cleanup before we sysprep
 ################################################################################
 
+Write-Host "Waiting for windefend to report as running"
+$service = Get-Service "Windefend"
+$service.WaitForStatus("Running","00:10:00")
+
 Write-Host "Run antivirus"
 Push-Location "C:\Program Files\Windows Defender"
 


### PR DESCRIPTION
When setting preferences on Windows Defender, if the windefend service is not running, it will fail with obscure errors. To resolve this I'm adding a wait until the windefend service is found running before proceeding to set the preferences and run a scan to finalize image generation.