### PR TITLE
macOS 10.13 Week 40 Software Updates

### DIFF
--- a/images/macos/macos-10.13-Readme.md
+++ b/images/macos/macos-10.13-Readme.md
@@ -4,7 +4,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 ## Image Changes
 
-The following Java versions are available on the VM image: 7, 8, 11, 12.
+The following Java versions are available on the VM image: 7, 8, 11, 12, 13.
 	Java 9 and 10 were deprecated.
 
 Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overloaded by complex licensing, end-user restrictions, and lack of long-term support. In this image change, we replaced the JDKs with tested, certified, LTS builds of OpenJDK from Azul Systems. Java developers can now build and run production Java applications using Azul Systems Zulu Enterprise builds of OpenJDK without incurring additional support costs. This new offering is designed to make Microsoft hosted Java builds and deployments worry-free by incorporating quarterly security updates and bug fixes as well as critical out-of-band updates and patches as needed.
@@ -23,6 +23,7 @@ Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overl
 - Java 1.8: OpenJDK RE (Zulu 8.40.0.25-CA-macosx) (build 1.8.0_222-b10) (default)
 - Java 11: OpenJDK RE Zulu11.33+15-CA (build 11.0.4+11-LTS)
 - Java 12: OpenJDK RE Zulu12.3+11-CA (build 12.0.2+3)
+- java 13 : OpenJDK RE Zulu13.27+9-CA (build 13+33)
 - Node.js 6.17.0
 - NVM 0.33.11
 - NVM - Installed node versions:
@@ -294,7 +295,7 @@ xcversion simulators --install='iOS 8.4'
 | lldb                  | 3.1.4508709                               |
 | ndk-bundle            | 18.1.5063045                              |
 | ProGuard              | 5.3.3                                     |
-| Android Emulator      | 29.2.0                                    |
+| Android Emulator      | 29.2.1                                    |
 
 ### Google APIs
 
@@ -318,10 +319,11 @@ xcversion simulators --install='iOS 8.4'
 
 ### Visual Studio for Mac
 
-- 8.2.6.26
+- 8.3.0.1805
 
 ### Mono
 
+- 6.4.0
 - 6.0.0
 - 5.18.1
 - 5.16.1
@@ -337,6 +339,7 @@ xcversion simulators --install='iOS 8.4'
 
 ### Xamarin.iOS SDK
 
+- 13.2.0.42
 - 12.14.0.114
 - 12.8.0.2
 - 12.6.0.25
@@ -356,6 +359,7 @@ xcversion simulators --install='iOS 8.4'
 
 ### Xamarin.Android SDK
 
+- 10.0.0.43
 - 9.4.1.0
 - 9.3.0-23
 - 9.2.3-0
@@ -373,7 +377,8 @@ xcversion simulators --install='iOS 8.4'
 
 ### Xamarin.Mac SDK
 
-- 5.16.1.17
+- 6.2.0.42
+- 5.16.1.24
 - 5.8.0.0
 - 5.6.0.25
 - 5.3.1.28

--- a/images/macos/macos-10.13-Readme.md
+++ b/images/macos/macos-10.13-Readme.md
@@ -2,13 +2,6 @@
 
 The following software is installed on machines in the Azure Pipelines **macOS-10.13** VM image ('Hosted macOS High Sierra' pool).
 
-## Image Changes
-
-The following Java versions are available on the VM image: 7, 8, 11, 12, 13.
-	Java 9 and 10 were deprecated.
-
-Previously, Microsoft hosted Mac machines had JDKs pre-installed that were overloaded by complex licensing, end-user restrictions, and lack of long-term support. In this image change, we replaced the JDKs with tested, certified, LTS builds of OpenJDK from Azul Systems. Java developers can now build and run production Java applications using Azul Systems Zulu Enterprise builds of OpenJDK without incurring additional support costs. This new offering is designed to make Microsoft hosted Java builds and deployments worry-free by incorporating quarterly security updates and bug fixes as well as critical out-of-band updates and patches as needed.
-
 #### Xcode 10.1 set by default
 
 ## Operating System


### PR DESCRIPTION
Software updates:
- java 13 : OpenJDK Runtime Environment Zulu13.27+9-CA (build 13+33)

Android:
- Android Emulator 29.2.1 

Xamarin:
- Visual Studio for Mac: 8.3.0.1805
- Mono Version: 6.4.0
- Xamarin.iOS SDK Version: 13.2.0.42
- Xamarin.Mac SDK Version: 5.16.1.24
- Xamarin.Mac SDK Version: 6.2.0.42
- Xamarin.Android SDK Version: 10.0.0.43