### PR TITLE
Fix ubuntu scripts so they'll find the latest dotnet core 3.0.

### DIFF
--- a/images/linux/scripts/installers/1604/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/1604/dotnetcore-sdk.sh
@@ -8,7 +8,7 @@
 source $HELPER_SCRIPTS/apt.sh
 source $HELPER_SCRIPTS/document.sh
 
-LATEST_DOTNET_PACKAGE=dotnet-sdk-2.1
+LATEST_DOTNET_PACKAGE=dotnet-sdk-3.0
 
 LSB_RELEASE=$(lsb_release -rs)
 

--- a/images/linux/scripts/installers/1804/dotnetcore-sdk.sh
+++ b/images/linux/scripts/installers/1804/dotnetcore-sdk.sh
@@ -8,7 +8,7 @@
 source $HELPER_SCRIPTS/apt.sh
 source $HELPER_SCRIPTS/document.sh
 
-LATEST_DOTNET_PACKAGE=dotnet-sdk-2.2
+LATEST_DOTNET_PACKAGE=dotnet-sdk-3.0
 
 LSB_RELEASE=$(lsb_release -rs)
 


### PR DESCRIPTION
This adds 3.0 as the latest dotnet core sdk available so that it gets installed . Otherwise it has to be found in the releases page which apparently doesn't include the very latest.