### PR TITLE
Add Clang VS component group to VS 2019 image

### DIFF
--- a/images/win/scripts/Installers/Vs2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Vs2019/Install-VS2019.ps1
@@ -112,6 +112,7 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.Component.Windows10SDK.18362 ' + `
               '--add Microsoft.VisualStudio.ComponentGroup.Azure.CloudServices ' + `
               '--add Microsoft.VisualStudio.ComponentGroup.Azure.ResourceManager.Tools ' + `
+              '--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang ' + `
               '--add Microsoft.VisualStudio.ComponentGroup.Web.CloudTools ' + `
               '--add Microsoft.VisualStudio.Workload.Azure ' + `
               '--add Microsoft.VisualStudio.Workload.Data ' + `


### PR DESCRIPTION
Relates to #270

Based on previous PRs, I assume this is all that is required, but please let me know if anything else is.

The component ID can be verified at https://docs.microsoft.com/en-gb/visualstudio/install/workload-component-id-vs-enterprise?view=vs-2019#desktop-development-with-c.

(Additionally, I noticed when running `Install-VS2019.ps1` locally that there seem to be some invalid component IDs in the script e.g. `Microsoft.VisualStudio.Component.VC.v141`.)