### PR TITLE
MacOS 10.13 software updates week 41

### DIFF
--- a/images/macos/macos-10.13-Readme.md
+++ b/images/macos/macos-10.13-Readme.md
@@ -6,7 +6,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 ## Operating System
 
-- OS X 10.13.6 (17G8030) **High Sierra**
+- OS X 10.13.6 (17G8037) **High Sierra**
 
 ## Installed Software
 
@@ -23,22 +23,22 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 	v6.17.1
 	v8.16.1
 	v10.16.3
-	v12.10.0
+	v12.11.1
 - PowerShell 6.2.3
 - Python 2.7.16
 - Python 3.7.4
-- Ruby 2.6.4p104
+- Ruby 2.6.5p114
 - .NET Core SDK 1.0.1, 1.0.4, 1.1.4, 1.1.5, 1.1.7, 1.1.8, 1.1.9, 1.1.10, 1.1.11, 1.1.12, 1.1.13, 2.0.0, 2.0.3, 2.1.100, 2.1.101, 2.1.102, 2.1.103, 2.1.104, 2.1.105, 2.1.503, 2.1.504, 2.1.505, 2.1.2, 2.1.200, 2.1.201, 2.1.300, 2.1.301, 2.1.4, 2.1.400, 2.1.401 2.1.402 2.1.502, 2.1.504, 2.2.101, 2.2.102, 2.2.103, 2.2.104, 2.2.105
-- Go 1.13
+- Go 1.13.1
 
 ### Package Management
 
 - Bundler 2.0.2
 - Carthage 0.33.0
-- CocoaPods 1.7.5
+- CocoaPods 1.8.1
 - Homebrew 2.1.11
 - NPM 3.10.10
-- Yarn 1.17.3
+- Yarn 1.19.0
 - NuGet 4.7.0.5148
 - pip 19.1.1(python 2.7)
 - pip 19.1.1(python 3.7)
@@ -60,9 +60,9 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 ### Tools
 
-- fastlane 2.131.0
+- fastlane 2.133.0
 - App Center CLI 1.2.2
-- Azure-CLI 2.0.72
+- Azure-CLI 2.0.74
 
 ### Pre-cached tools
 - Python (available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task)
@@ -96,7 +96,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 ### Xcode Support Tools
 
-- Nomad CLI 3.0.3
+- Nomad CLI 3.0.6
 - Nomad CLI IPA 0.14.3
 - xcpretty 0.3.0
 - xctool 0.3.5
@@ -312,7 +312,7 @@ xcversion simulators --install='iOS 8.4'
 
 ### Visual Studio for Mac
 
-- 8.3.0.1805
+- 8.3.1.18
 
 ### Mono
 


### PR DESCRIPTION
macOS:
System Version: macOS 10.13.6 (**17G8037**)

- ruby 2.6.5p114
- CocoaPods 1.8.1
- Nomad CLI 3.0.6
- fastlane 2.133.0
- Yarn 1.19.0
- azure-cli 2.0.74
- Go 1.13.1
- NVM - Installed node versions: v12.11.1 

Xamarin:
- Visual Studio for Mac: 8.3.1.18