### PR TITLE
Pin cloud foundry cli version 6.46.1 because the latest version windows download is broken

### DIFF
--- a/images/win/scripts/Installers/Install-CloudFoundryCli.ps1
+++ b/images/win/scripts/Installers/Install-CloudFoundryCli.ps1
@@ -8,7 +8,7 @@ Import-Module -Name ImageHelpers
 
 # Download the latest cf cli exe
 # Pin the version to the latest windows supported one, windows is not supported after version 6.46.1 according to the release notes
-Invoke-WebRequest -UseBasicParsing -Uri "https://packages.cloudfoundry.org/stable?release=windows64&version=6.46.1&source=github-rel" -OutFile cf-cli.zip
+Invoke-WebRequest -UseBasicParsing -Uri "https://packages.cloudfoundry.org/stable?release=windows64-exe&version=6.46.1&source=github-rel" -OutFile cf-cli.zip
 
 # Create directory for cf cli
 $cf_cli_path = "C:\cf-cli"

--- a/images/win/scripts/Installers/Install-CloudFoundryCli.ps1
+++ b/images/win/scripts/Installers/Install-CloudFoundryCli.ps1
@@ -7,7 +7,8 @@
 Import-Module -Name ImageHelpers
 
 # Download the latest cf cli exe
-Invoke-WebRequest -UseBasicParsing -Uri "https://packages.cloudfoundry.org/stable?release=windows64-exe&source=github" -OutFile cf-cli.zip
+# Pin the version to the latest windows supported one, windows is not supported after version 6.46.1 according to the release notes
+Invoke-WebRequest -UseBasicParsing -Uri "https://packages.cloudfoundry.org/stable?release=windows64&version=6.46.1&source=github-rel" -OutFile cf-cli.zip
 
 # Create directory for cf cli
 $cf_cli_path = "C:\cf-cli"


### PR DESCRIPTION
Related issues 
https://github.com/cloudfoundry/cli/issues/1819
https://github.com/cloudfoundry/cli/issues/1820