### PR TITLE
Update/lock Maven version to 3.6.2

### DIFF
--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -34,11 +34,11 @@ apt-fast install -y --no-install-recommends ant ant-optional
 echo "ANT_HOME=/usr/share/ant" | tee -a /etc/environment
 
 # Install Maven
-curl -sL https://www-eu.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.zip -o maven.zip
+curl -sL https://www-eu.apache.org/dist/maven/maven-3/3.6.2/binaries/apache-maven-3.6.2-bin.zip -o maven.zip
 unzip -d /usr/share maven.zip
 rm maven.zip
-ln -s /usr/share/apache-maven-3.6.1/bin/mvn /usr/bin/mvn
-echo "M2_HOME=/usr/share/apache-maven-3.6.1" | tee -a /etc/environment
+ln -s /usr/share/apache-maven-3.6.2/bin/mvn /usr/bin/mvn
+echo "M2_HOME=/usr/share/apache-maven-3.6.2" | tee -a /etc/environment
 
 # Install Gradle
 # This script downloads the latest HTML list of releases at https://gradle.org/releases/.

--- a/images/win/scripts/Installers/Install-JavaTools.ps1
+++ b/images/win/scripts/Installers/Install-JavaTools.ps1
@@ -63,7 +63,7 @@ setx JAVA_HOME_11_X64 $latestJava11Install /M
 # Install Java tools
 # Force chocolatey to ignore dependencies on Ant and Maven or else they will download the Oracle JDK
 choco install ant -y -i
-choco install maven -y -i
+choco install maven -y -i --version=3.6.2
 choco install gradle -y
 
 # Move maven variables to Machine. They may not be in the environment for this script so we need to read them from the registry.


### PR DESCRIPTION
On ubuntu-latest, the version of Maven is still 3.6.1. I was bitten by https://issues.apache.org/jira/browse/MNG-6642 so here is a PR to upgrade the version.
I noticed that the version on Windows hosted agents is not locked, which seems very dangerous to me (sometimes latest Maven versions are quite broken). So I took the liberty to lock the chocolatey package to 3.6.2 for consistency.