### PR TITLE
Add sbt scripts back to Windows packer scripts

### DIFF
--- a/images/win/scripts/Installers/Validate-Sbt.ps1
+++ b/images/win/scripts/Installers/Validate-Sbt.ps1
@@ -6,7 +6,7 @@
 
 if((Get-Command -Name 'sbt'))
 {
-    Write-Host "sbt $(sbt --script-version) is on the path"
+    Write-Host "sbt is on the path"
 }
 else
 {
@@ -14,15 +14,5 @@ else
     exit 1
 }
 
-$sbtVersion = $(sbt --script-version)
-
-# Adding description of the software to Markdown
-$SoftwareName = "sbt"
-
-$Description = @"
-_Version:_ $sbtVersion<br/>
-_Environment:_
-* PATH: contains location of sbt.bat
-"@
-
-Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description
+# This works around issue where sbt --script-version does some copies and breaks the build
+Add-SoftwareDetailsToMarkdown -SoftwareName "sbt" -DescriptionMarkdown ""

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -619,6 +619,12 @@
         {
             "type": "powershell",
             "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-Sbt.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-Svn.ps1"
             ]
         },

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -315,6 +315,12 @@
         {
             "type": "powershell",
             "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-Sbt.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-Svn.ps1"
             ]
         },

--- a/images/win/vs2019-Server2019-Azure.json
+++ b/images/win/vs2019-Server2019-Azure.json
@@ -285,6 +285,12 @@
         {
             "type": "powershell",
             "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-Sbt.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-Svn.ps1"
             ]
         },

--- a/images/win/vs2019-Server2019-Azure.json
+++ b/images/win/vs2019-Server2019-Azure.json
@@ -595,6 +595,12 @@
         {
             "type": "powershell",
             "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-Sbt.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-Chrome.ps1"
             ]
         },


### PR DESCRIPTION
The validation of sbt was causing build failures so I've added back the steps to install it but remove the specific lines during validation that were causing issues.