### PR TITLE
Overriding main WebProductList.xml feed of WebPI

### DIFF
--- a/images/win/scripts/Installers/Install-ServiceFabricSDK.ps1
+++ b/images/win/scripts/Installers/Install-ServiceFabricSDK.ps1
@@ -11,4 +11,4 @@ New-Item -Path $temp_install_dir -ItemType Directory -Force
 
 Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
 
-WebpiCmd.exe /Install /Products:MicrosoftAzure-ServiceFabric-CoreSDK /AcceptEula
+WebpiCmd.exe /Install /Products:MicrosoftAzure-ServiceFabric-CoreSDK /AcceptEula /XML:https://webpifeed.blob.core.windows.net/webpifeed/5.1/WebProductList.xml


### PR DESCRIPTION
In favor of Issue - #1015 
Currently during image generation ([here](https://github.com/microsoft/azure-pipelines-image-generation/blob/02cdd72e2bd058ae3d078d0b5d71d0240c994f2c/images/win/scripts/Installers/Vs2017/Initialize-VM.ps1#L102)) we are getting WebpiCmd [package ](https://chocolatey.org/packages/webpicmd)from chocolatey which is outdated hence corresponding feed is also outdated due to which newly generated images doesn't contain newly released Service Fabric SDKs.
In the following PR, I'm overriding the default feed to latest feed.