### PR TITLE
keep the windows/installer folder in Finalize-VM.ps1

### DIFF
--- a/images/win/scripts/Installers/Finalize-VM.ps1
+++ b/images/win/scripts/Installers/Finalize-VM.ps1
@@ -15,7 +15,6 @@ Write-Host "Clean up various directories"
     "$env:windir\\logs",
     "$env:windir\\winsxs\\manifestcache",
     "$env:windir\\Temp",
-    "$env:windir\\Installer",
     "$env:TEMP"
 ) | ForEach-Object {
     if (Test-Path $_) {


### PR DESCRIPTION
Keep the windows/installer folder so the choco uninstall will work properly. This is a fix for this [issue](https://github.com/github/pe-actions-compute/issues/20).