### PR TITLE
Add a default commit_url val for win images

### DIFF
--- a/images/win/WindowsContainer1803-Azure.json
+++ b/images/win/WindowsContainer1803-Azure.json
@@ -20,7 +20,7 @@
         "commit_file": "C:\\image\\commit.txt",
         "metadata_file": "C:\\image\\metadata.txt",
         "helper_script_folder": "C:\\Program Files\\WindowsPowerShell\\Modules\\",
-        "commit_url": "",
+        "commit_url": "LATEST",
         "install_user": "installer",
         "install_password": null,
         "capture_name_prefix": "packer",

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -20,7 +20,7 @@
         "commit_file": "C:\\image\\commit.txt",
         "metadata_file": "C:\\image\\metadata.txt",
         "helper_script_folder": "C:\\Program Files\\WindowsPowerShell\\Modules\\",
-        "commit_url": "",
+        "commit_url": "LATEST",
         "install_user": "installer",
         "install_password": null,
         "capture_name_prefix": "packer",

--- a/images/win/vs2019-Server2019-Azure.json
+++ b/images/win/vs2019-Server2019-Azure.json
@@ -20,7 +20,7 @@
         "commit_file": "C:\\image\\commit.txt",
         "metadata_file": "C:\\image\\metadata.txt",
         "helper_script_folder": "C:\\Program Files\\WindowsPowerShell\\Modules\\",
-        "commit_url": "",
+        "commit_url": "LATEST",
         "install_user": "installer",
         "install_password": null,
         "capture_name_prefix": "packer",


### PR DESCRIPTION
This PR [add commit url to commit.txt file]((https://github.com/microsoft/azure-pipelines-image-generation/pull/1367) ) introduced commit_url variable which is empty by default, but image-generation pipelines or you build the image on your local will know nothing about that and as a result everything stuck on:

**"Write-Output {{user `commit_url`}} > {{user `commit_file` }}"** 

Because of the empty string powershell asks for parameter:

**cmdlet Write-Output at command pipeline position 1
Supply values for the following parameters:** 

This can be a way to fix that issue.
