### PR TITLE
Install Boost toolcache via NPM

### DIFF
--- a/images/linux/scripts/installers/1604/hosted-tool-cache.sh
+++ b/images/linux/scripts/installers/1604/hosted-tool-cache.sh
@@ -18,6 +18,9 @@ azcopy --recursive \
        --source https://vstsagenttools.blob.core.windows.net/tools/hostedtoolcache/linux \
        --destination $AGENT_TOOLSDIRECTORY
 
+# Remove Boost toolcache folder manually because azcopy doesn't support exclude flag
+rm -rf $AGENT_TOOLSDIRECTORY/Boost/*
+
 # Install tools from hosted tool cache
 original_directory=$PWD
 setups=$(find $AGENT_TOOLSDIRECTORY -name setup.sh)
@@ -26,6 +29,16 @@ for setup in $setups; do
 	cd $(dirname $setup);
 	./$(basename $setup);
 	cd $original_directory;
+done;
+
+chmod -R 777 $AGENT_TOOLSDIRECTORY
+
+echo "Installing npm-toolcache..."
+BOOST_VERSIONS=( '1.69.0' )
+
+for BOOST_VERSION in ${BOOST_VERSIONS[@]}; do
+    echo "Install boost-$BOOST_VERSION"
+    npm install toolcache-boost-ubuntu-1604-x64@$BOOST_VERSION --registry=https://buildcanary.pkgs.visualstudio.com/PipelineCanary/_packaging/hostedtoolcache/npm/registry/
 done;
 
 DocumentInstalledItem "Python (available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task)"

--- a/images/linux/scripts/installers/1604/hosted-tool-cache.sh
+++ b/images/linux/scripts/installers/1604/hosted-tool-cache.sh
@@ -18,9 +18,6 @@ azcopy --recursive \
        --source https://vstsagenttools.blob.core.windows.net/tools/hostedtoolcache/linux \
        --destination $AGENT_TOOLSDIRECTORY
 
-# Remove Boost toolcache folder manually because azcopy doesn't support exclude flag
-rm -rf $AGENT_TOOLSDIRECTORY/Boost/*
-
 # Install tools from hosted tool cache
 original_directory=$PWD
 setups=$(find $AGENT_TOOLSDIRECTORY -name setup.sh)

--- a/images/linux/scripts/installers/1604/hosted-tool-cache.sh
+++ b/images/linux/scripts/installers/1604/hosted-tool-cache.sh
@@ -28,8 +28,6 @@ for setup in $setups; do
 	cd $original_directory;
 done;
 
-chmod -R 777 $AGENT_TOOLSDIRECTORY
-
 echo "Installing npm-toolcache..."
 BOOST_VERSIONS=( '1.69.0' )
 

--- a/images/linux/scripts/installers/1604/hosted-tool-cache.sh
+++ b/images/linux/scripts/installers/1604/hosted-tool-cache.sh
@@ -18,6 +18,9 @@ azcopy --recursive \
        --source https://vstsagenttools.blob.core.windows.net/tools/hostedtoolcache/linux \
        --destination $AGENT_TOOLSDIRECTORY
 
+# Remove Boost toolcache folder manually because azcopy doesn't support exclude flag
+rm -rf $AGENT_TOOLSDIRECTORY/Boost/*
+
 # Install tools from hosted tool cache
 original_directory=$PWD
 setups=$(find $AGENT_TOOLSDIRECTORY -name setup.sh)
@@ -27,6 +30,8 @@ for setup in $setups; do
 	./$(basename $setup);
 	cd $original_directory;
 done;
+
+chmod -R 777 $AGENT_TOOLSDIRECTORY
 
 echo "Installing npm-toolcache..."
 BOOST_VERSIONS=( '1.69' )

--- a/images/linux/scripts/installers/1604/hosted-tool-cache.sh
+++ b/images/linux/scripts/installers/1604/hosted-tool-cache.sh
@@ -29,7 +29,7 @@ for setup in $setups; do
 done;
 
 echo "Installing npm-toolcache..."
-BOOST_VERSIONS=( '1.69.0' )
+BOOST_VERSIONS=( '1.69' )
 
 for BOOST_VERSION in ${BOOST_VERSIONS[@]}; do
     echo "Install boost-$BOOST_VERSION"

--- a/images/linux/scripts/installers/1804/hosted-tool-cache.sh
+++ b/images/linux/scripts/installers/1804/hosted-tool-cache.sh
@@ -28,8 +28,6 @@ for setup in $setups; do
 	cd $original_directory;
 done;
 
-chmod -R 777 $AGENT_TOOLSDIRECTORY
-
 echo "Installing npm-toolcache..."
 BOOST_VERSIONS=( '1.69.0' )
 

--- a/images/linux/scripts/installers/1804/hosted-tool-cache.sh
+++ b/images/linux/scripts/installers/1804/hosted-tool-cache.sh
@@ -18,6 +18,9 @@ azcopy --recursive \
        --source https://vstsagenttools.blob.core.windows.net/tools/hostedtoolcache/ubuntu-1804 \
        --destination $AGENT_TOOLSDIRECTORY
 
+# Remove Boost toolcache folder manually because azcopy doesn't support exclude flag
+rm -rf $AGENT_TOOLSDIRECTORY/Boost/*
+
 # Install tools from hosted tool cache
 original_directory=$PWD
 setups=$(find $AGENT_TOOLSDIRECTORY -name setup.sh)
@@ -27,6 +30,8 @@ for setup in $setups; do
 	./$(basename $setup);
 	cd $original_directory;
 done;
+
+chmod -R 777 $AGENT_TOOLSDIRECTORY
 
 echo "Installing npm-toolcache..."
 BOOST_VERSIONS=( '1.69' )

--- a/images/linux/scripts/installers/1804/hosted-tool-cache.sh
+++ b/images/linux/scripts/installers/1804/hosted-tool-cache.sh
@@ -18,9 +18,6 @@ azcopy --recursive \
        --source https://vstsagenttools.blob.core.windows.net/tools/hostedtoolcache/ubuntu-1804 \
        --destination $AGENT_TOOLSDIRECTORY
 
-# Remove Boost toolcache folder manually because azcopy doesn't support exclude flag
-rm -rf $AGENT_TOOLSDIRECTORY/Boost/*
-
 # Install tools from hosted tool cache
 original_directory=$PWD
 setups=$(find $AGENT_TOOLSDIRECTORY -name setup.sh)

--- a/images/linux/scripts/installers/1804/hosted-tool-cache.sh
+++ b/images/linux/scripts/installers/1804/hosted-tool-cache.sh
@@ -18,6 +18,9 @@ azcopy --recursive \
        --source https://vstsagenttools.blob.core.windows.net/tools/hostedtoolcache/ubuntu-1804 \
        --destination $AGENT_TOOLSDIRECTORY
 
+# Remove Boost toolcache folder manually because azcopy doesn't support exclude flag
+rm -rf $AGENT_TOOLSDIRECTORY/Boost/*
+
 # Install tools from hosted tool cache
 original_directory=$PWD
 setups=$(find $AGENT_TOOLSDIRECTORY -name setup.sh)
@@ -26,6 +29,16 @@ for setup in $setups; do
 	cd $(dirname $setup);
 	./$(basename $setup);
 	cd $original_directory;
+done;
+
+chmod -R 777 $AGENT_TOOLSDIRECTORY
+
+echo "Installing npm-toolcache..."
+BOOST_VERSIONS=( '1.69.0' )
+
+for BOOST_VERSION in ${BOOST_VERSIONS[@]}; do
+    echo "Install boost-$BOOST_VERSION"
+    npm install toolcache-boost-ubuntu-1804-x64@$BOOST_VERSION --registry=https://buildcanary.pkgs.visualstudio.com/PipelineCanary/_packaging/hostedtoolcache/npm/registry/
 done;
 
 DocumentInstalledItem "Python (available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task)"

--- a/images/linux/scripts/installers/1804/hosted-tool-cache.sh
+++ b/images/linux/scripts/installers/1804/hosted-tool-cache.sh
@@ -29,7 +29,7 @@ for setup in $setups; do
 done;
 
 echo "Installing npm-toolcache..."
-BOOST_VERSIONS=( '1.69.0' )
+BOOST_VERSIONS=( '1.69' )
 
 for BOOST_VERSION in ${BOOST_VERSIONS[@]}; do
     echo "Install boost-$BOOST_VERSION"

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -187,19 +187,6 @@
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {
-            "type": "shell",
-            "scripts":[
-                "{{template_dir}}/scripts/installers/boost.sh"
-            ],
-            "environment_vars": [
-                "METADATA_FILE={{user `metadata_file`}}",
-                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
-                "BOOST_VERSIONS=1.69.0",
-                "BOOST_DEFAULT=1.69.0"
-            ],
-            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-        },
-        {
             "type": "file",
             "source": "{{user `metadata_file`}}",
             "destination": "{{template_dir}}/Ubuntu1804-README.md",

--- a/images/linux/ubuntu1804.json
+++ b/images/linux/ubuntu1804.json
@@ -187,6 +187,19 @@
             "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
         },
         {
+            "type": "shell",
+            "scripts":[
+                "{{template_dir}}/scripts/installers/boost.sh"
+            ],
+            "environment_vars": [
+                "METADATA_FILE={{user `metadata_file`}}",
+                "HELPER_SCRIPTS={{user `helper_script_folder`}}",
+                "BOOST_VERSIONS=1.69.0",
+                "BOOST_DEFAULT=1.69.0"
+            ],
+            "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+        },
+        {
             "type": "file",
             "source": "{{user `metadata_file`}}",
             "destination": "{{template_dir}}/Ubuntu1804-README.md",

--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -64,7 +64,7 @@ setx AGENT_TOOLSDIRECTORY $ToolsDirectory /M
 
 # Install Boost ToolCache
 $BoostVersionsToolcacheInstall = @(
-    "toolcache-boost-windows-x64@1.69.0"
+    "toolcache-boost-windows-x64@1.69"
 )
 
 Install-NpmPackage -Name $BoostVersionsToolcacheInstall

--- a/images/win/scripts/Installers/Download-ToolCache.ps1
+++ b/images/win/scripts/Installers/Download-ToolCache.ps1
@@ -4,48 +4,70 @@
 ##  Desc:  Download tool cache
 ################################################################################
 
-Function InstallTool
-{
-    Param
-    (
-        [System.Object]$ExecutablePath
+Function Install-NpmPackage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [System.String[]]
+        $Name,
+        [System.String]
+        $NpmRegistry="https://buildcanary.pkgs.visualstudio.com/PipelineCanary/_packaging/hostedtoolcache/npm/registry/"
     )
 
-    Write-Host $ExecutablePath.DirectoryName
-    Set-Location -Path $ExecutablePath.DirectoryName
-    Get-Location | Write-Host
-    if (Test-Path 'tool.zip')
-    {
+    foreach($packageName in $Name) {
+        Write-Host "Installing npm '$packageName' package from '$NpmRegistry'"
+        npm install $packageName --registry=$NpmRegistry
+    }
+}
+
+Function InstallTool {
+    [CmdletBinding()]
+    param(
+        [System.IO.FileInfo]$ExecutablePath
+    )
+
+    Set-Location -Path $ExecutablePath.DirectoryName -PassThru | Write-Host
+    if (Test-Path 'tool.zip') {
         Expand-Archive 'tool.zip' -DestinationPath '.'
     }
     cmd.exe /c 'install_to_tools_cache.bat'
 }
 
+# ToolCache Blob
 $SourceUrl = "https://vstsagenttools.blob.core.windows.net/tools"
 
+# HostedToolCache Path
 $Dest = "C:/"
-
 $Path = "hostedtoolcache/windows"
-
-$env:Path = "C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy;" + $env:Path
-
-Write-Host "Started AzCopy from $SourceUrl to $Dest"
-
-AzCopy /Source:$SourceUrl /Dest:$Dest  /S /V /Pattern:$Path
-
 $ToolsDirectory = $Dest + $Path
 
-$current = Get-Location
-Set-Location -Path $ToolsDirectory
+# Add AzCopy to the Path
+$env:Path = "C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy;" + $env:Path
+Write-Host "Started AzCopy from $SourceUrl to $Dest"
+AzCopy /Source:$SourceUrl /Dest:$Dest /S /V /Pattern:$Path
+
+# Temporary remove Boost
+Remove-Item -Path C:\hostedtoolcache\windows\Boost -Force -Recurse
+
+# Install ToolCache
+Push-Location -Path $ToolsDirectory
 
 Get-ChildItem -Recurse -Depth 4 -Filter install_to_tools_cache.bat | ForEach-Object {
-    #In order to work correctly Python 3.4 x86 must be installed after x64, this is achieved by current toolcache catalog structure
-    InstallTool($_)
+    InstallTool -ExecutablePath $_
 }
 
-Set-Location -Path $current
+Pop-Location
 
+# Define AGENT_TOOLSDIRECTORY environment variable
+$env:AGENT_TOOLSDIRECTORY = $ToolsDirectory
 setx AGENT_TOOLSDIRECTORY $ToolsDirectory /M
+
+# Install Boost ToolCache
+$BoostVersionsToolcacheInstall = @(
+    "toolcache-boost-windows-x64@1.69.0"
+)
+
+Install-NpmPackage -Name $BoostVersionsToolcacheInstall
 
 #junction point from the previous Python2 directory to the toolcache Python2
 $python2Dir = (Get-Item -Path ($ToolsDirectory + '/Python/2.7*/x64')).FullName

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -371,12 +371,6 @@
         {
             "type": "powershell",
             "scripts":[
-                "{{ template_dir }}/scripts/Installers/Install-NodeLts.ps1"
-            ]
-        },
-        {
-            "type": "powershell",
-            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-JavaTools.ps1"
             ]
         },

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -269,6 +269,12 @@
         {
             "type": "powershell",
             "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-NodeLts.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Download-ToolCache.ps1"
             ]
         },

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -61,9 +61,7 @@
         {
             "type": "powershell",
             "inline":[
-                "New-Item -Path {{user `image_folder`}} -ItemType Directory -Force",
-                "Write-Output {{user `commit_url`}} > {{user `commit_file` }}",
-                "Write-Host (Get-Content -Path {{user `commit_file`}})"
+                "New-Item -Path {{user `image_folder`}} -ItemType Directory -Force"
             ]
         },
         {

--- a/images/win/vs2019-Server2019-Azure.json
+++ b/images/win/vs2019-Server2019-Azure.json
@@ -341,12 +341,6 @@
         {
             "type": "powershell",
             "scripts":[
-                "{{ template_dir }}/scripts/Installers/Install-NodeLts.ps1"
-            ]
-        },
-        {
-            "type": "powershell",
-            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-JavaTools.ps1"
             ]
         },

--- a/images/win/vs2019-Server2019-Azure.json
+++ b/images/win/vs2019-Server2019-Azure.json
@@ -62,9 +62,7 @@
         {
             "type": "powershell",
             "inline":[
-                "New-Item -Path {{user `image_folder`}} -ItemType Directory -Force",
-                "Write-Output {{user `commit_url`}} > {{user `commit_file` }}",
-                "Write-Host (Get-Content -Path {{user `commit_file`}})"
+                "New-Item -Path {{user `image_folder`}} -ItemType Directory -Force"
             ]
         },
         {

--- a/images/win/vs2019-Server2019-Azure.json
+++ b/images/win/vs2019-Server2019-Azure.json
@@ -239,6 +239,12 @@
         {
             "type": "powershell",
             "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-NodeLts.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Download-ToolCache.ps1"
             ]
         },


### PR DESCRIPTION
This PR replaces installation of Boost in tool cache with NPM approach.
Affected images:

Ubuntu-1604
Ubuntu-1804
VS-2017
VS-2019