### PR TITLE
Update cmake.sh to 3.15 stable

### DIFF
--- a/images/linux/scripts/installers/cmake.sh
+++ b/images/linux/scripts/installers/cmake.sh
@@ -13,7 +13,7 @@ echo "Checking to see if the installer script has already been run"
 if command -v cmake; then
     echo "Example variable already set to $EXAMPLE_VAR"
 else
-	curl -sL https://cmake.org/files/v3.12/cmake-3.12.4-Linux-x86_64.sh -o cmakeinstall.sh \
+	curl -sL https://cmake.org/files/v3.15/cmake-3.15.5-Linux-x86_64.sh -o cmakeinstall.sh \
 	&& chmod +x cmakeinstall.sh \
 	&& ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir \
 	&& rm cmakeinstall.sh


### PR DESCRIPTION
`cmake 3.15.5 `has been released in 2019.10.30. Update CMake to 3.15 stable could let us to make it possible to apply the latest CMake in our  build.
