### PR TITLE
add VS2019 component ArchitectureToolsManaged

### DIFF
--- a/images/win/scripts/Installers/Vs2019/Install-VS2019.ps1
+++ b/images/win/scripts/Installers/Vs2019/Install-VS2019.ps1
@@ -117,6 +117,7 @@ $WorkLoads = '--allWorkloads --includeRecommended ' + `
               '--add Microsoft.VisualStudio.ComponentGroup.Azure.ResourceManager.Tools ' + `
               '--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang ' + `
               '--add Microsoft.VisualStudio.ComponentGroup.Web.CloudTools ' + `
+              '--add Microsoft.VisualStudio.ComponentGroup.ArchitectureTools.Managed ' + `
               '--add Microsoft.VisualStudio.Workload.Azure ' + `
               '--add Microsoft.VisualStudio.Workload.Data ' + `
               '--add Microsoft.VisualStudio.Workload.DataScience ' + `


### PR DESCRIPTION
This was added in VS2017. This is causing an upgrade to VS2019 pipelines to fail due to not being able to build without the missing component.