### PR TITLE
Update to WDK 1903 in VS2019 image

### DIFF
--- a/images/win/scripts/Installers/Vs2019/Install-WDK.ps1
+++ b/images/win/scripts/Installers/Vs2019/Install-WDK.ps1
@@ -4,13 +4,13 @@
 ##  Desc:  Install the Windows Driver Kit
 ################################################################################
 
-# Version: 10.0.17763.0
+# Version: 10.0.18362.0
 # Update Validate-WDK.ps1 if the version changes!
 # There doesn't seem to be any way to check the version programmatically
 
 # Requires Windows SDK with the same version number as the WDK
-$winSdkUrl = "https://go.microsoft.com/fwlink/p/?LinkID=2023014"
-$wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2026156"
+$winSdkUrl = "https://go.microsoft.com/fwlink/p/?linkid=2083338"
+$wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2085767"
 
 # `winsdksetup.exe /features + /quiet` installs all features without showing the GUI
 $sdkExitCode = Install-EXE -Url $winSdkUrl -Name "winsdksetup.exe" -ArgumentList ("/features", "+", "/quiet")
@@ -32,10 +32,9 @@ if ($wdkExitCode -ne 0)
 
 # Need to install the VSIX to get the build targets when running VSBuild
 # Write-Host "Installing WDK.vsix"
-<# ISSUE - VSIX installer failing on VS2019
  $process = Start-Process `
     -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\VSIXInstaller.exe" `
-    -ArgumentList ("/quiet", '"C:\Program Files (x86)\Windows Kits\10\Vsix\WDK.vsix"') `
+    -ArgumentList ("/quiet", '"C:\Program Files (x86)\Windows Kits\10\Vsix\VS2019\WDK.vsix"') `
     -Wait `
     -PassThru
 
@@ -51,4 +50,3 @@ else
 }
 
 exit $exitCode
-#>

--- a/images/win/scripts/Installers/Vs2019/Validate-WDK.ps1
+++ b/images/win/scripts/Installers/Vs2019/Validate-WDK.ps1
@@ -8,7 +8,7 @@
 $SoftwareName = "Windows Driver Kit"
 
 $Description = @"
-_Version:_ 10.0.17763.0<br/>
+_Version:_ 10.0.18362.0<br/>
 "@
 
 Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description


### PR DESCRIPTION
Addresses #1192

When building Windows Drivers in the pipeline, SDK and WDK versions must match. The VS2019 updates the SDK to 1903, so WDK needs to also update to 1903 (10.0.18362.0 version)