### PR TITLE
Add secret variables to sensitive-variables array.

### DIFF
--- a/images/win/WindowsContainer1803-Azure.json
+++ b/images/win/WindowsContainer1803-Azure.json
@@ -26,6 +26,7 @@
         "capture_name_prefix": "packer",
         "image_version": "dev"
     },
+    "sensitive-variables": ["install_password", "ssh_password", "client_secret"],
     "builders": [
         {
             "name": "vhd",


### PR DESCRIPTION
Windows Container image didn't have a spec of sensitive variables, this should avoid any of those to be shown in logs.