### PR TITLE
MacOS 10.14 Software updates Week 2

### DIFF
--- a/images/macos/macos-10.14-Readme.md
+++ b/images/macos/macos-10.14-Readme.md
@@ -2,7 +2,7 @@
 
 The following software is installed on machines in the Azure Pipelines **macOS-10.14** VM image ('Hosted macOS' pool).
 
-#### Xcode 11.1 set by default
+#### Xcode 11.2.1 set by default
 
 ## Operating System
 

--- a/images/macos/macos-10.14-Readme.md
+++ b/images/macos/macos-10.14-Readme.md
@@ -21,24 +21,24 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - NVM 0.33.11
 - NVM - Installed node versions:
 	v6.17.1
-	v8.16.2
-	v10.17.0
-	v12.13.1
-	v13.3.0
+	v8.17.0
+	v10.18.0
+	v12.14.0
+	v13.5.0
 - PowerShell 6.2.3
 - Python 2.7.17
-- Python 3.7.5
+- Python 3.7.6
 - Ruby 2.6.5p114
 - .NET Core SDK 1.0.1 1.0.4 1.1.10 1.1.11 1.1.12 1.1.13 1.1.4 1.1.5 1.1.7 1.1.8 1.1.9 2.0.0 2.0.3 2.1.100 2.1.101 2.1.102 2.1.103 2.1.104 2.1.105 2.1.2 2.1.200 2.1.201 2.1.202 2.1.300 2.1.301 2.1.302 2.1.4 2.1.400 2.1.401 2.1.402 2.1.403 2.1.500 2.1.502 2.1.503 2.1.504 2.1.505 2.2.100 2.2.101 2.2.102 2.2.103 2.2.104 2.2.105
-- Go 1.13.4
+- Go 1.13.5
 
 
 ### Package Management
 
-- Bundler 2.0.2
+- Bundler 2.1.3
 - Carthage 0.34.0
 - CocoaPods 1.8.4
-- Homebrew 2.2.1
+- Homebrew 2.2.2
 - NPM 3.10.10
 - Yarn 1.21.1
 - NuGet 4.7.0.5148
@@ -55,17 +55,22 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 - curl 7.67.0 (x86_64-apple-darwin17.7.0) libcurl/7.67.0 SecureTransport zlib/1.2.11)
 - Git 2.24.1
-- Git LFS 2.8.0
+- Git LFS 2.9.2
 - GNU Wget 1.20.3 built on darwin18.7.0
 - Subversion (SVN) 1.13.0
-- GNU parallel 20191122
+- GNU parallel 20191222
 
 ### Tools
 
-- fastlane 2.137.0
+- fastlane 2.139.0
 - App Center CLI 1.2.2
-- Azure-CLI 2.0.77
-- CMake 3.15.5
+- Azure-CLI 2.0.78
+- CMake 3.16.2
+
+### Browsers
+
+- Google Chrome 79.0.3945.88
+- ChromeDriver 79.0.3945.36
 
 ### Pre-cached tools
 
@@ -282,7 +287,7 @@ xcversion simulators --install='iOS 8.4'
 | lldb                  | 2.3.3614996                               |
 | ndk-bundle            | 18.1.5063045                              |
 | ProGuard              | 5.3.3                                     |
-| Android Emulator      | 29.3.0                                    |
+| Android Emulator      | 29.3.2                                    |
 
 ### Google APIs
 
@@ -306,7 +311,7 @@ xcversion simulators --install='iOS 8.4'
 
 ### Visual Studio for Mac
 
-- 8.3.10.2
+- 8.3.11.1
 
 
 ### Mono
@@ -318,9 +323,7 @@ xcversion simulators --install='iOS 8.4'
 - 5.12.0
 - 5.10.1
 - 5.8.1
-- 5.8.0
 - 5.4.1.7
-- 5.4.0.201
 - 5.2.0.224
 - 5.0.1.1
 - 4.8.1.0
@@ -335,7 +338,6 @@ xcversion simulators --install='iOS 8.4'
 - 12.8.0.2
 - 12.6.0.25
 - 12.2.1.16
-- 12.2.1.11
 - 12.0.0.15
 - 11.14.0.13
 - 11.12.0.4
@@ -351,16 +353,13 @@ xcversion simulators --install='iOS 8.4'
 ### Xamarin.Android SDK
 
 - 10.0.6.2
-- 10.0.3.0
 - 9.4.1.0
 - 9.3.0-23
 - 9.2.3-0
 - 9.1.8-0
 - 9.0.0-20
-- 9.0.0-18
 - 8.3.3-2
 - 8.2.0-16
-- 8.2.0-15
 - 8.1.5-0
 - 8.0.0-33
 - 7.4.5-1
@@ -378,11 +377,9 @@ xcversion simulators --install='iOS 8.4'
 - 5.6.0.25
 - 5.3.1.28
 - 5.2.1.16
-- 5.2.1.9
 - 4.6.0.13
 - 4.4.1.193
 - 4.2.1.28
-- 4.2.0.20
 - 4.0.0.216
 - 3.8.0.49
 - 3.6.3.3


### PR DESCRIPTION
Software updates:
- Python 3.7.6
- Git LFS: git-lfs/2.9.2 (GitHub; darwin amd64; go 1.13.5)
- Homebrew 2.2.2
- CMake 3.16.2
- Bundler version 2.1.3
- fastlane 2.139.0
- azure-cli 2.0.78
- Go 1.13.5
- NVM v8.17.0 *, v10.18.0 *, v12.14.0 *, v13.5.0 *
- GNU parallel 20191222
- Google Chrome 79.0.3945.88
- ChromeDriver 79.0.3945.36
- Android Emulator 29.3.2
- Xamarin:
- Visual Studio for Mac: 8.3.11.1

Deprecate:
- Mono 5.4.0, 5.8.0
- Xamarin.iOS SDK 12.2.1.11
- Xamarin.Android SDK 8.2.0-15, 9.0.0-18, 10.0.3.0
- Xamarin.Mac SDK 4.2.0.20, 5.2.1.9