### PR TITLE
MacOS 10.13 Software Updates Week 3

### DIFF
--- a/images/macos/macos-10.13-Readme.md
+++ b/images/macos/macos-10.13-Readme.md
@@ -22,19 +22,19 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - NVM - Installed node versions:
 	v6.17.1
 	v8.17.0
-	v10.18.0
-	v12.14.0
-	v13.5.0
+	v10.18.1
+	v12.14.1
+	v13.6.0
 - PowerShell 6.2.3
 - Python 2.7.17
 - Python 3.7.6
 - Ruby 2.6.5p114
 - .NET Core SDK 1.0.1, 1.0.4, 1.1.4, 1.1.5, 1.1.7, 1.1.8, 1.1.9, 1.1.10, 1.1.11, 1.1.12, 1.1.13, 2.0.0, 2.0.3, 2.1.100, 2.1.101, 2.1.102, 2.1.103, 2.1.104, 2.1.105, 2.1.503, 2.1.504, 2.1.505, 2.1.2, 2.1.200, 2.1.201, 2.1.300, 2.1.301, 2.1.4, 2.1.400, 2.1.401 2.1.402 2.1.502, 2.1.504, 2.2.101, 2.2.102, 2.2.103, 2.2.104, 2.2.105
-- Go 1.13.5
+- Go 1.13.6
 
 ### Package Management
 
-- Bundler 2.1.3
+- Bundler 2.1.4
 - Carthage 0.34.0
 - CocoaPods 1.8.4
 - Homebrew 2.2.2
@@ -52,7 +52,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 ### Utilities
 
-- curl 7.67.0 (x86_64-apple-darwin17.7.0) libcurl/7.67.0 SecureTransport zlib/1.2.11
+- curl 7.68.0 (x86_64-apple-darwin17.7.0) libcurl/7.68.0 SecureTransport zlib/1.2.11
 - Git 2.24.1
 - Git LFS 2.9.2
 - GNU Wget 1.20.3
@@ -61,29 +61,29 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 ### Tools
 
-- fastlane 2.139.0
+- fastlane 2.140.0
 - App Center CLI 1.2.2
-- Azure-CLI 2.0.78
+- Azure-CLI 2.0.79
 - CMake 3.16.2
 
 ### Browsers
 
-- Google Chrome 79.0.3945.88
+- Google Chrome 79.0.3945.117
 - ChromeDriver 79.0.3945.36
 
 ### Pre-cached tools
 - Python (available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task)
-  - 2.7.16
-  - 3.5.7
-  - 3.6.9
-  - 3.7.5
-  - 3.8.0
+  - 2.7.17
+  - 3.5.9
+  - 3.6.10
+  - 3.7.6
+  - 3.8.1
   - pypy2
   - pypy3
 - Ruby (available through the [Use Ruby Version](https://go.microsoft.com/fwlink/?linkid=2005989) task)
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
 
 ### Xcode
 | Version                | Build   | Path                          |
@@ -294,7 +294,7 @@ xcversion simulators --install='iOS 8.4'
 | lldb                  | 3.1.4508709                               |
 | ndk-bundle            | 18.1.5063045                              |
 | ProGuard              | 5.3.3                                     |
-| Android Emulator      | 29.3.2                                    |
+| Android Emulator      | 29.3.4                                    |
 
 ### Google APIs
 


### PR DESCRIPTION
Software Updates Week 3

- curl 7.68.0 (x86_64-apple-darwin17.7.0) libcurl/7.68.0 SecureTransport zlib/1.2.11
- Bundler version 2.1.4
- fastlane 2.140.0
- azure-cli 2.0.79
- Go 1.13.6
- NVM - Installed node versions:
- v10.18.1
- v12.14.1
- v13.6.0
- macOS toolcache Python 2.7.17 3.5.9 3.6.10 3.7.6 3.8.1
- macOS toolcache Ruby 2.4.9 2.5.7 2.6.5
- Google Chrome 79.0.3945.117
- Android Emulator 29.3.4