### PR TITLE
Install Windows Updates during WinCon build.

### DIFF
--- a/images/win/WindowsContainer1803-Azure.json
+++ b/images/win/WindowsContainer1803-Azure.json
@@ -163,6 +163,12 @@
             ]
         },
         {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1"
+            ]
+        },
+        {
             "type": "windows-restart",
             "restart_timeout": "30m"
         },

--- a/images/win/scripts/Installers/Install-WindowsUpdates.ps1
+++ b/images/win/scripts/Installers/Install-WindowsUpdates.ps1
@@ -1,0 +1,10 @@
+################################################################################
+##  File:  Install-WindowsUpdates.ps1
+##  Desc:  Install Windows Updates.
+##         Should be run at end just before Antivirus.
+################################################################################
+
+Write-Host "Run windows updates"
+Install-Module -Name PSWindowsUpdate -Force -AllowClobber
+Get-WUInstall -WindowsUpdate -AcceptAll -Install -UpdateType Software -IgnoreReboot
+Get-WUInstall -MicrosoftUpdate -AcceptAll -Install -IgnoreUserInput -IgnoreReboot


### PR DESCRIPTION
We need to make sure the image is fully patched since there can be replication delays from base image in Azure Gallery.