### PR TITLE
MacOS 10.14 Software updates Week 5

### DIFF
--- a/images/macos/macos-10.14-Readme.md
+++ b/images/macos/macos-10.14-Readme.md
@@ -4,6 +4,15 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 #### Xcode 11.3.1 set by default
 
+## OS X info
+- System Version: macOS 10.14.6 (18G2022)
+- Kernel Version: Darwin 18.7.0
+- Boot Volume: Macintosh HD
+- Boot Mode: Normal
+- User Name: runner (runner)
+- Secure Virtual Memory: Enabled
+- System Integrity Protection: Enabled
+
 ## Installed Software
 ### Language and Runtime
 - Java 1.7: (Zulu 7.36.0.5-CA-macosx) (build 1.7.0_252-b10)

--- a/images/macos/macos-10.14-Readme.md
+++ b/images/macos/macos-10.14-Readme.md
@@ -2,29 +2,18 @@
 
 The following software is installed on machines in the Azure Pipelines **macOS-10.14** VM image ('Hosted macOS' pool).
 
-#### Xcode 11.2.1 set by default
-
-:warning: Xcode 11.3.1 will be set as default in the next week
-
-## OS X info
-- System Version: macOS 10.14.6 (18G2022)
-- Kernel Version: Darwin 18.7.0
-- Boot Volume: Macintosh HD
-- Boot Mode: Normal
-- User Name: runner (runner)
-- Secure Virtual Memory: Enabled
-- System Integrity Protection: Enabled
+#### Xcode 11.3.1 set by default
 
 ## Installed Software
 ### Language and Runtime
 - Java 1.7: (Zulu 7.36.0.5-CA-macosx) (build 1.7.0_252-b10)
-- Java 1.8: (Zulu 8.44.0.9-CA-macosx) (build 1.8.0_242-b20) (default)
+- Java 1.8: (Zulu 8.44.0.11-CA-macosx) (build 1.8.0_242-b20) (default)
 - Java 11: Zulu11.37+17-CA (build 11.0.6+10-LTS)
 - Java 12: Zulu12.3+11-CA (build 12.0.2+3)
 - Java 13: Zulu13.29+9-CA (build 13.0.2+6-MTS)
 - Node.js v6.17.0
 - NVM 0.33.11
-- NVM - Cached node versions: v6.17.1 v8.17.0 v10.18.1 v12.14.1 v13.6.0
+- NVM - Cached node versions: v6.17.1 v8.17.0 v10.18.1 v12.14.1 v13.7.0
 - PowerShell 6.2.3
 - Python 2.7.17
 - Python 3.7.6
@@ -45,6 +34,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - Pip 19.3.1 (python 3.7)
 - Rustup 1.21.1
 - Miniconda 4.7.12
+- RubyGems 3.1.2
 
 ### Project Management
 - Apache Maven 3.6.3
@@ -53,10 +43,10 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 ### Utilities
 - Curl 7.68.0
 - Git: 2.25.0
-- Git LFS: 2.9.2
+- Git LFS: 2.10.0
 - GNU Wget 1.20.3
 - Subversion (SVN) 1.13.0
-- GNU parallel 20191222
+- GNU parallel 20200122
 - OpenSSL 1.0.2t  10 Sep 2019
 - jq 1.6
 - gpg (GnuPG) 2.2.19
@@ -68,30 +58,30 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - Azure CLI 2.0.80
 
 ### Browsers
-- Google Chrome 79.0.3945.130 
+- Google Chrome 79.0.3945.130
 - ChromeDriver 79.0.3945.36
 
 ### Toolcache
-#### Ruby (available through the [Use Ruby Version](https://go.microsoft.com/fwlink/?linkid=2005989) task)
+#### Ruby
 - 2.4.9
 - 2.5.7
 - 2.6.5
 - 2.7.0
 
-#### Python (available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task)
+#### Python
 - 2.7.17
 - 3.5.9
 - 3.6.10
 - 3.7.6
 - 3.8.1
 
-#### PyPy (available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task)
-- 2.7.13
+#### PyPy
+- 2.7.17
 - 3.6.9
 
 ### Xamarin
 #### Visual Studio for Mac
-- 8.4.1.4
+- 8.4.2.59
 
 #### Mono
 - 6.6.0.155
@@ -186,7 +176,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | 9.4.1                          | 9F2000                         | /Applications/Xcode_9.4.1.app  |
 
 #### Xcode Support Tools
-- Nomad CLI 3.0.6
+- Nomad CLI 3.1.2
 - Nomad CLI IPA ipa 0.14.3
 - xcpretty 0.3.0
 - xctool 0.3.7


### PR DESCRIPTION
### Language and Runtime
- Java 1.8: (Zulu 8.44.0.11-CA-macosx) (build 1.8.0_242-b20) (default)
- NVM - Cached node versions: v13.7.0
### Package Management
- RubyGems 3.1.2
### Utilities
- Git LFS: 2.10.0
- GNU parallel 20200122
### Toolcache
+ #### PyPy  
+ 2.7.17  
### Xamarin
#### Visual Studio for Mac
+ 8.4.2.59  
#### Xcode Support Tools
+ Nomad CLI 3.1.2  