### PR TITLE
Fixing chocolatey installation

### DIFF
--- a/images/win/scripts/Installers/WindowsContainer1803/Initialize-VM.ps1
+++ b/images/win/scripts/Installers/WindowsContainer1803/Initialize-VM.ps1
@@ -72,6 +72,7 @@ else {
 }
 
 # Run the installer
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor "Tls12"
 Invoke-Expression ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
 
 # Turn off confirmation


### PR DESCRIPTION
Issue:
Unable to install chocolatey - The request was aborted: Could not create SSL/TLS secure channel.

Fix:
Enable Tls1.2.
