### PR TITLE
MacOS 10.15 Software updates Week 7

### DIFF
--- a/images/macos/macos-10.15-Readme.md
+++ b/images/macos/macos-10.15-Readme.md
@@ -1,0 +1,254 @@
+# Azure Pipelines hosted macOS image
+
+The following software is installed on machines in the Azure Pipelines **macOS-10.15** VM image ('Hosted macOS 10.15' pool).
+
+#### Xcode 11.3.1 set by default
+
+## Operating System
+- OS X 10.15.3 (19D76) **Catalina**
+
+## Installed Software
+### Language and Runtime
+- Java 1.7: (Zulu 7.36.0.5-CA-macosx) (build 1.7.0_252-b10)
+- Java 1.8: (Zulu 8.44.0.11-CA-macosx) (build 1.8.0_242-b20) (default)
+- Java 11: Zulu11.37+17-CA (build 11.0.6+10-LTS)
+- Java 12: Zulu12.3+11-CA (build 12.0.2+3)
+- Java 13: Zulu13.29+9-CA (build 13.0.2+6-MTS)
+- Rust 1.41.0
+- Clang/LLVM 9.0.1
+- gcc-8 (Homebrew GCC 8.3.0_2) 8.3.0
+- gcc-9 (Homebrew GCC 9.2.0_3) 9.2.0
+- GNU Fortran (Homebrew GCC 8.3.0_2) 8.3.0
+- GNU Fortran (Homebrew GCC 9.2.0_3) 9.2.0
+- Node.js v12.15.0
+- NVM 0.33.11
+- NVM - Cached node versions: v6.17.1 v8.17.0 v10.19.0 v12.15.0 v13.8.0
+- PowerShell 6.2.4
+- Python 2.7.17
+- Python 3.7.6
+- Ruby 2.6.5p114
+- .NET SDK 2.0.0 3.0.100 3.0.101 3.0.102 3.1.100 3.1.101
+- Go 1.13.7
+- PHP 7.4.2
+
+### Package Management
+- Rustup 1.21.1
+- Bundler version 2.1.4
+- Carthage 0.34.0
+- CocoaPods 1.8.4
+- Homebrew 2.2.5
+- NPM 6.13.4
+- Yarn 1.22.0
+- NuGet 5.3.1.6268
+- Pip 19.3.1 (python 2.7)
+- Pip 19.3.1 (python 3.7)
+- Miniconda 4.7.12
+- RubyGems 3.1.2
+
+### Project Management
+- Apache Maven 3.6.3
+- Gradle 6.1.1
+
+### Utilities
+- Curl 7.68.0
+- Git: 2.25.0
+- Git LFS: 2.10.0
+- GNU Wget 1.20.3
+- Subversion (SVN) 1.13.0
+- GNU parallel 20200122
+- OpenSSL 1.0.2t  10 Sep 2019
+- jq 1.6
+- gpg (GnuPG) 2.2.19
+- psql (PostgreSQL) 12.1
+- aria2 1.35.0
+- azcopy 10.3.4
+
+### Tools
+- Fastlane 2.141.0
+- Cmake 3.16.3
+- App Center CLI 2.3.3
+- Azure CLI 2.0.81
+
+### Browsers
+- Google Chrome 80.0.3987.87
+- ChromeDriver 80.0.3987.16
+- Microsoft Edge 80.0.361.48
+- MSEdgeDriver 80.0.361.48
+
+### Toolcache
+#### Ruby
+- 2.4.9
+- 2.5.7
+- 2.6.5
+- 2.7.0
+
+#### Python
+- 2.7.17
+- 3.5.9
+- 3.6.10
+- 3.7.6
+- 3.8.1
+
+#### PyPy
+- 2.7.17
+- 3.6.9
+
+### Xamarin
+#### Visual Studio for Mac
+- 8.4.4.91
+
+#### Mono
+- 6.6.0.155
+- 6.4.0.208
+
+#### Xamarin.iOS
+- 13.10.0.17
+- 13.8.3.0
+- 13.6.0.12
+- 13.4.0.2
+
+#### Xamarin.Mac
+- 6.10.0.17
+- 6.8.3.0
+- 6.6.0.12
+- 6.4.0.2
+
+#### Xamarin.Android
+- 10.1.3
+- 10.0.6
+
+#### Unit Test Framework
+- NUnit 3.6.1
+
+### Xcode
+| Version                           | Build                             | Path                              |
+| --------------------------------- | --------------------------------- | --------------------------------- |
+| 11.4 (beta)                       | 11N111s                           | /Applications/Xcode_11.4_beta.app |
+| 11.3.1 (default)                  | 11C505                            | /Applications/Xcode_11.3.1.app    |
+| 11.3                              | 11C29                             | /Applications/Xcode_11.3.app      |
+| 11.2.1                            | 11B500                            | /Applications/Xcode_11.2.1.app    |
+| 11.2                              | 11B52                             | /Applications/Xcode_11.2.app      |
+| 11.1                              | 11A1027                           | /Applications/Xcode_11.1.app      |
+| 11.0                              | 11A420a                           | /Applications/Xcode_11.app        |
+
+#### Xcode Support Tools
+- Nomad CLI 3.1.2
+- Nomad CLI IPA ipa 0.14.3
+- xcpretty 0.3.0
+- xctool 0.3.7
+- xcversion 2.6.3
+
+#### Installed SDKs
+| SDK                                          | SDK Name                                     | Xcode Version                                |
+| -------------------------------------------- | -------------------------------------------- | -------------------------------------------- |
+| macOS 10.15                                  | macosx10.15                                  | 11.0, 11.1, 11.2, 11.2.1, 11.3, 11.3.1, 11.4 |
+| iOS 13.0                                     | iphoneos13.0                                 | 11.0                                         |
+| iOS 13.1                                     | iphoneos13.1                                 | 11.1                                         |
+| iOS 13.2                                     | iphoneos13.2                                 | 11.2, 11.2.1, 11.3, 11.3.1                   |
+| iOS 13.4                                     | iphoneos13.4                                 | 11.4                                         |
+| Simulator - iOS 13.0                         | iphonesimulator13.0                          | 11.0                                         |
+| Simulator - iOS 13.1                         | iphonesimulator13.1                          | 11.1                                         |
+| Simulator - iOS 13.2                         | iphonesimulator13.2                          | 11.2, 11.2.1, 11.3, 11.3.1                   |
+| Simulator - iOS 13.4                         | iphonesimulator13.4                          | 11.4                                         |
+| tvOS 13.0                                    | appletvos13.0                                | 11.0, 11.1                                   |
+| tvOS 13.2                                    | appletvos13.2                                | 11.2, 11.2.1, 11.3, 11.3.1                   |
+| tvOS 13.4                                    | appletvos13.4                                | 11.4                                         |
+| Simulator - tvOS 13.0                        | appletvsimulator13.0                         | 11.0, 11.1                                   |
+| Simulator - tvOS 13.2                        | appletvsimulator13.2                         | 11.2, 11.2.1, 11.3, 11.3.1                   |
+| Simulator - tvOS 13.4                        | appletvsimulator13.4                         | 11.4                                         |
+| watchOS 6.0                                  | watchos6.0                                   | 11.0, 11.1                                   |
+| watchOS 6.1                                  | watchos6.1                                   | 11.2, 11.2.1, 11.3, 11.3.1                   |
+| watchOS 6.2                                  | watchos6.2                                   | 11.4                                         |
+| Simulator - watchOS 6.0                      | watchsimulator6.0                            | 11.0, 11.1                                   |
+| Simulator - watchOS 6.1                      | watchsimulator6.1                            | 11.2, 11.2.1, 11.3, 11.3.1                   |
+| Simulator - watchOS 6.2                      | watchsimulator6.2                            | 11.4                                         |
+| DriverKit 19.0                               | driverkit.macosx19.0                         | 11.0, 11.1, 11.2, 11.2.1, 11.3, 11.3.1, 11.4 |
+
+#### Installed Simulators
+| OS                                                                                                                                                                                                                       | Xcode Version                                                                                                                                                                                                            | Simulators                                                                                                                                                                                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| iOS 13.0                                                                                                                                                                                                                 | 11.0                                                                                                                                                                                                                     | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                          |
+| iOS 13.1                                                                                                                                                                                                                 | 11.1                                                                                                                                                                                                                     | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                          |
+| iOS 13.2                                                                                                                                                                                                                 | 11.2<br>11.2.1                                                                                                                                                                                                           | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                          |
+| iOS 13.3                                                                                                                                                                                                                 | 11.3<br>11.3.1                                                                                                                                                                                                           | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                          |
+| iOS 13.4                                                                                                                                                                                                                 | 11.4                                                                                                                                                                                                                     | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad (7th generation)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation) |
+| tvOS 13.0                                                                                                                                                                                                                | 11.0<br>11.1                                                                                                                                                                                                             | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                        |
+| tvOS 13.2                                                                                                                                                                                                                | 11.2<br>11.2.1                                                                                                                                                                                                           | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                        |
+| tvOS 13.3                                                                                                                                                                                                                | 11.3<br>11.3.1                                                                                                                                                                                                           | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                        |
+| tvOS 13.4                                                                                                                                                                                                                | 11.4                                                                                                                                                                                                                     | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                        |
+| watchOS 6.0                                                                                                                                                                                                              | 11.0<br>11.1                                                                                                                                                                                                             | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                 |
+| watchOS 6.1                                                                                                                                                                                                              | 11.2<br>11.2.1<br>11.3<br>11.3.1                                                                                                                                                                                         | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                 |
+| watchOS 6.2                                                                                                                                                                                                              | 11.4                                                                                                                                                                                                                     | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                 |
+
+### Android
+#### Android SDK Tools
+| Package Name                       | Description                        |
+| ---------------------------------- | ---------------------------------- |
+| tools                              | Android SDK Tools, Revision 26.1.1 |
+
+#### Android SDK Platform-Tools
+| Package Name                                | Description                                 |
+| ------------------------------------------- | ------------------------------------------- |
+| platform-tools                              | Android SDK Platform-Tools, Revision 29.0.5 |
+
+#### Android SDK Platforms
+| Package Name                        | Description                         |
+| ----------------------------------- | ----------------------------------- |
+| android-24                          | Android SDK Platform 24, Revision 2 |
+| android-25                          | Android SDK Platform 25, Revision 3 |
+| android-26                          | Android SDK Platform 26, Revision 2 |
+| android-27                          | Android SDK Platform 27, Revision 3 |
+| android-28                          | Android SDK Platform 28, Revision 6 |
+| android-29                          | Android SDK Platform 29, Revision 4 |
+
+#### Android SDK Build-Tools
+| Package Name                             | Description                              |
+| ---------------------------------------- | ---------------------------------------- |
+| build-tools-24.0.0                       | Android SDK Build-Tools, Revision 24.0.0 |
+| build-tools-24.0.1                       | Android SDK Build-Tools, Revision 24.0.1 |
+| build-tools-24.0.2                       | Android SDK Build-Tools, Revision 24.0.2 |
+| build-tools-24.0.3                       | Android SDK Build-Tools, Revision 24.0.3 |
+| build-tools-25.0.0                       | Android SDK Build-Tools, Revision 25.0.0 |
+| build-tools-25.0.1                       | Android SDK Build-Tools, Revision 25.0.1 |
+| build-tools-25.0.2                       | Android SDK Build-Tools, Revision 25.0.2 |
+| build-tools-25.0.3                       | Android SDK Build-Tools, Revision 25.0.3 |
+| build-tools-26.0.0                       | Android SDK Build-Tools, Revision 26.0.0 |
+| build-tools-26.0.1                       | Android SDK Build-Tools, Revision 26.0.1 |
+| build-tools-26.0.2                       | Android SDK Build-Tools, Revision 26.0.2 |
+| build-tools-26.0.3                       | Android SDK Build-Tools, Revision 26.0.3 |
+| build-tools-27.0.0                       | Android SDK Build-Tools, Revision 27.0.0 |
+| build-tools-27.0.1                       | Android SDK Build-Tools, Revision 27.0.1 |
+| build-tools-27.0.2                       | Android SDK Build-Tools, Revision 27.0.2 |
+| build-tools-27.0.3                       | Android SDK Build-Tools, Revision 27.0.3 |
+| build-tools-28.0.0                       | Android SDK Build-Tools, Revision 28.0.0 |
+| build-tools-28.0.1                       | Android SDK Build-Tools, Revision 28.0.1 |
+| build-tools-28.0.2                       | Android SDK Build-Tools, Revision 28.0.2 |
+| build-tools-28.0.3                       | Android SDK Build-Tools, Revision 28.0.3 |
+| build-tools-29.0.0                       | Android SDK Build-Tools, Revision 29.0.0 |
+| build-tools-29.0.1                       | Android SDK Build-Tools, Revision 29.0.1 |
+| build-tools-29.0.2                       | Android SDK Build-Tools, Revision 29.0.2 |
+| build-tools-29.0.3                       | Android SDK Build-Tools, Revision 29.0.3 |
+
+#### Android Utils
+| Package Name     | Version          |
+| ---------------- | ---------------- |
+| cmake            | 3.6.4111459      |
+| lldb             | 3.1.4508709      |
+| ndk-bundle       | 18.1.5063045     |
+| Android Emulator | 29.3.4           |
+
+#### Android Google APIs
+| Package Name                | Description                 |
+| --------------------------- | --------------------------- |
+| addon-google_apis-google-21 | Google APIs, Revision 1     |
+| addon-google_apis-google-22 | Google APIs, Revision 1     |
+| addon-google_apis-google-23 | Google APIs, Revision 1     |
+| addon-google_apis-google-24 | Google APIs, Revision 1     |
+
+#### Extra Packages
+| Package Name                                    | Version                                         |
+| ----------------------------------------------- | ----------------------------------------------- |
+| Android Support Repository                      | 47.0.0                                          |
+| Google Play services                            | 49                                              |
+| Google Repository                               | 58                                              |
+| Intel x86 Emulator Accelerator (HAXM installer) | 7.5.1                                           |


### PR DESCRIPTION
## OS X info
- System Version: macOS 10.15.3 (19D76)
- Kernel Version: Darwin 19.3.0
## Installed Software
### Language and Runtime
- Java 1.8: (Zulu 8.44.0.11-CA-macosx) (build 1.8.0_242-b20) (default)
- Rust 1.41.0
- Clang/LLVM 9.0.1
- gcc-8 (Homebrew GCC 8.3.0_2) 8.3.0
- gcc-9 (Homebrew GCC 9.2.0_3) 9.2.0
- GNU Fortran (Homebrew GCC 8.3.0_2) 8.3.0
- GNU Fortran (Homebrew GCC 9.2.0_3) 9.2.0
- Node.js v12.15.0
- NVM - Cached node versions: v6.17.1 v8.17.0 v10.19.0 v12.15.0 v13.8.0
- PowerShell 6.2.4
- Go 1.13.7
- PHP 7.4.2
### Package Management
- Homebrew 2.2.5
- Yarn 1.22.0
### Project Management
- Gradle 6.1.1
### Utilities
- Git LFS: 2.10.0
- GNU parallel 20200122
- psql (PostgreSQL) 12.1
- aria2 1.35.0
- azcopy 10.3.4
### Tools
- Fastlane 2.141.0
- Cmake 3.16.3
- Azure CLI 2.0.81
### Browsers
- Google Chrome 80.0.3987.87 
- ChromeDriver 80.0.3987.16
- Microsoft Edge 80.0.361.48 
- MSEdgeDriver 80.0.361.48
### Toolcache
#### PyPy
- 2.7.17
### Xamarin
#### Visual Studio for Mac
- 8.4.4.91
### Xcode
| Version                           | Build                             | Path                              |
| --------------------------------- | --------------------------------- | --------------------------------- |
| 11.4 (beta)                       | 11N111s                           | /Applications/Xcode_11.4_beta.app |
### Android
#### Android SDK Build-Tools
Android SDK Build-Tools, Revision 29.0.3