### PR TITLE
MacOS 10.15 Software updates Week 9

### DIFF
--- a/images/macos/macos-10.15-Readme.md
+++ b/images/macos/macos-10.15-Readme.md
@@ -20,16 +20,16 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - gcc-9 (Homebrew GCC 9.2.0_3) 9.2.0
 - GNU Fortran (Homebrew GCC 8.3.0_2) 8.3.0
 - GNU Fortran (Homebrew GCC 9.2.0_3) 9.2.0
-- Node.js v12.16.0
+- Node.js v12.16.1
 - NVM 0.33.11
-- NVM - Cached node versions: v6.17.1 v8.17.0 v10.19.0 v12.16.0 v13.8.0
+- NVM - Cached node versions: v6.17.1 v8.17.0 v10.19.0 v12.16.1 v13.9.0
 - PowerShell 6.2.4
 - Python 2.7.17
 - Python 3.7.6
 - Ruby 2.7.0p0
-- .NET SDK 2.0.0 3.0.100 3.0.101 3.0.102 3.1.100 3.1.101
+- .NET SDK 2.0.0 3.0.100 3.0.101 3.0.102 3.0.103 3.1.100 3.1.101
 - Go 1.13.8
-- PHP 7.4.2
+- PHP 7.4.3
 
 ### Package Management
 - Rustup 1.21.1
@@ -55,26 +55,26 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - Git LFS: 2.10.0
 - GNU Wget 1.20.3
 - Subversion (SVN) 1.13.0
-- GNU parallel 20200122
+- GNU parallel 20200222
 - OpenSSL 1.0.2t  10 Sep 2019
 - jq 1.6
 - gpg (GnuPG) 2.2.19
-- psql (PostgreSQL) 12.1
+- psql (PostgreSQL) 12.2
 - aria2 1.35.0
 - azcopy 10.3.4
 
 ### Tools
-- Fastlane 2.141.0
+- Fastlane 2.142.0
 - Cmake 3.16.4
 - App Center CLI 2.3.3
-- Azure CLI 2.0.83
+- Azure CLI 2.1.0
 
 ### Browsers
-- Google Chrome 80.0.3987.106 
+- Google Chrome 80.0.3987.122
 - ChromeDriver 80.0.3987.106
-- Microsoft Edge 80.0.361.54 
-- MSEdgeDriver 80.0.361.54
-- Mozilla Firefox 73.0
+- Microsoft Edge 80.0.361.57
+- MSEdgeDriver 80.0.361.57
+- Mozilla Firefox 73.0.1
 - geckodriver 0.26.0
 
 ### Toolcache
@@ -97,7 +97,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 ### Xamarin
 #### Visual Studio for Mac
-- 8.4.5.19
+- 8.4.6.36
 
 #### Mono
 - 6.6.0.155
@@ -125,7 +125,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 ### Xcode
 | Version                           | Build                             | Path                              |
 | --------------------------------- | --------------------------------- | --------------------------------- |
-| 11.4 (beta)                       | 11N111s                           | /Applications/Xcode_11.4_beta.app |
+| 11.4 (beta)                       | 11N123k                           | /Applications/Xcode_11.4_beta.app |
 | 11.3.1 (default)                  | 11C505                            | /Applications/Xcode_11.3.1.app    |
 | 11.3                              | 11C29                             | /Applications/Xcode_11.3.app      |
 | 11.2.1                            | 11B500                            | /Applications/Xcode_11.2.1.app    |
@@ -172,7 +172,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | iOS 13.0                                                                                                                                                                                                                 | 11.0                                                                                                                                                                                                                     | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                          |
 | iOS 13.1                                                                                                                                                                                                                 | 11.1                                                                                                                                                                                                                     | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                          |
 | iOS 13.2                                                                                                                                                                                                                 | 11.2<br>11.2.1                                                                                                                                                                                                           | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                          |
-| iOS 13.3                                                                                                                                                                                                                 | 11.3<br>11.3.1                                                                                                                                                                                                           | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                          |
+| iOS 13.3                                                                                                                                                                                                                 | 11.3<br>11.3.1                                                                                                                                                                                                           | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad (7th generation)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation) |
 | iOS 13.4                                                                                                                                                                                                                 | 11.4                                                                                                                                                                                                                     | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad (7th generation)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation) |
 | tvOS 13.0                                                                                                                                                                                                                | 11.0<br>11.1                                                                                                                                                                                                             | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                        |
 | tvOS 13.2                                                                                                                                                                                                                | 11.2<br>11.2.1                                                                                                                                                                                                           | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                        |
@@ -191,7 +191,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 #### Android SDK Platform-Tools
 | Package Name                                | Description                                 |
 | ------------------------------------------- | ------------------------------------------- |
-| platform-tools                              | Android SDK Platform-Tools, Revision 29.0.5 |
+| platform-tools                              | Android SDK Platform-Tools, Revision 29.0.6 |
 
 #### Android SDK Platforms
 | Package Name                        | Description                         |
@@ -204,32 +204,33 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | android-29                          | Android SDK Platform 29, Revision 4 |
 
 #### Android SDK Build-Tools
-| Package Name                             | Description                              |
-| ---------------------------------------- | ---------------------------------------- |
-| build-tools-24.0.0                       | Android SDK Build-Tools, Revision 24.0.0 |
-| build-tools-24.0.1                       | Android SDK Build-Tools, Revision 24.0.1 |
-| build-tools-24.0.2                       | Android SDK Build-Tools, Revision 24.0.2 |
-| build-tools-24.0.3                       | Android SDK Build-Tools, Revision 24.0.3 |
-| build-tools-25.0.0                       | Android SDK Build-Tools, Revision 25.0.0 |
-| build-tools-25.0.1                       | Android SDK Build-Tools, Revision 25.0.1 |
-| build-tools-25.0.2                       | Android SDK Build-Tools, Revision 25.0.2 |
-| build-tools-25.0.3                       | Android SDK Build-Tools, Revision 25.0.3 |
-| build-tools-26.0.0                       | Android SDK Build-Tools, Revision 26.0.0 |
-| build-tools-26.0.1                       | Android SDK Build-Tools, Revision 26.0.1 |
-| build-tools-26.0.2                       | Android SDK Build-Tools, Revision 26.0.2 |
-| build-tools-26.0.3                       | Android SDK Build-Tools, Revision 26.0.3 |
-| build-tools-27.0.0                       | Android SDK Build-Tools, Revision 27.0.0 |
-| build-tools-27.0.1                       | Android SDK Build-Tools, Revision 27.0.1 |
-| build-tools-27.0.2                       | Android SDK Build-Tools, Revision 27.0.2 |
-| build-tools-27.0.3                       | Android SDK Build-Tools, Revision 27.0.3 |
-| build-tools-28.0.0                       | Android SDK Build-Tools, Revision 28.0.0 |
-| build-tools-28.0.1                       | Android SDK Build-Tools, Revision 28.0.1 |
-| build-tools-28.0.2                       | Android SDK Build-Tools, Revision 28.0.2 |
-| build-tools-28.0.3                       | Android SDK Build-Tools, Revision 28.0.3 |
-| build-tools-29.0.0                       | Android SDK Build-Tools, Revision 29.0.0 |
-| build-tools-29.0.1                       | Android SDK Build-Tools, Revision 29.0.1 |
-| build-tools-29.0.2                       | Android SDK Build-Tools, Revision 29.0.2 |
-| build-tools-29.0.3                       | Android SDK Build-Tools, Revision 29.0.3 |
+| Package Name                                 | Description                                  |
+| -------------------------------------------- | -------------------------------------------- |
+| build-tools-24.0.0                           | Android SDK Build-Tools, Revision 24.0.0     |
+| build-tools-24.0.1                           | Android SDK Build-Tools, Revision 24.0.1     |
+| build-tools-24.0.2                           | Android SDK Build-Tools, Revision 24.0.2     |
+| build-tools-24.0.3                           | Android SDK Build-Tools, Revision 24.0.3     |
+| build-tools-25.0.0                           | Android SDK Build-Tools, Revision 25.0.0     |
+| build-tools-25.0.1                           | Android SDK Build-Tools, Revision 25.0.1     |
+| build-tools-25.0.2                           | Android SDK Build-Tools, Revision 25.0.2     |
+| build-tools-25.0.3                           | Android SDK Build-Tools, Revision 25.0.3     |
+| build-tools-26.0.0                           | Android SDK Build-Tools, Revision 26.0.0     |
+| build-tools-26.0.1                           | Android SDK Build-Tools, Revision 26.0.1     |
+| build-tools-26.0.2                           | Android SDK Build-Tools, Revision 26.0.2     |
+| build-tools-26.0.3                           | Android SDK Build-Tools, Revision 26.0.3     |
+| build-tools-27.0.0                           | Android SDK Build-Tools, Revision 27.0.0     |
+| build-tools-27.0.1                           | Android SDK Build-Tools, Revision 27.0.1     |
+| build-tools-27.0.2                           | Android SDK Build-Tools, Revision 27.0.2     |
+| build-tools-27.0.3                           | Android SDK Build-Tools, Revision 27.0.3     |
+| build-tools-28.0.0                           | Android SDK Build-Tools, Revision 28.0.0     |
+| build-tools-28.0.1                           | Android SDK Build-Tools, Revision 28.0.1     |
+| build-tools-28.0.2                           | Android SDK Build-Tools, Revision 28.0.2     |
+| build-tools-28.0.3                           | Android SDK Build-Tools, Revision 28.0.3     |
+| build-tools-29.0.0                           | Android SDK Build-Tools, Revision 29.0.0     |
+| build-tools-29.0.1                           | Android SDK Build-Tools, Revision 29.0.1     |
+| build-tools-29.0.2                           | Android SDK Build-Tools, Revision 29.0.2     |
+| build-tools-29.0.3                           | Android SDK Build-Tools, Revision 29.0.3     |
+| build-tools-30.0.0-rc1                       | Android SDK Build-Tools, Revision 30.0.0 rc1 |
 
 #### Android Utils
 | Package Name     | Version          |
@@ -237,7 +238,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | cmake            | 3.6.4111459      |
 | lldb             | 3.1.4508709      |
 | ndk-bundle       | 18.1.5063045     |
-| Android Emulator | 29.3.4           |
+| Android Emulator | 30.0.0           |
 
 #### Android Google APIs
 | Package Name                | Description                 |


### PR DESCRIPTION
## Installed Software
### Language and Runtime
- Node.js v12.16.1
- NVM - Cached node versions: v6.17.1 v8.17.0 v10.19.0 v12.16.1 v13.9.0
- .NET SDK 3.0.103 
- PHP 7.4.3
### Utilities
- GNU parallel 20200222
- psql (PostgreSQL) 12.2
### Tools
- Fastlane 2.142.0
- Azure CLI 2.1.0
### Browsers
- Google Chrome 80.0.3987.122
- Microsoft Edge 80.0.361.57
- MSEdgeDriver 80.0.361.57
- Mozilla Firefox 73.0.1
### Xamarin
#### Visual Studio for Mac
- 8.4.6.36
### Xcode
| Version                           | Build                             | Path                              |
| --------------------------------- | --------------------------------- | --------------------------------- |
| 11.4 (beta)                       | 11N123k                           | /Applications/Xcode_11.4_beta.app |
#### Android SDK Platform-Tools
| Package Name                                | Description                                 |
| ------------------------------------------- | ------------------------------------------- |
| platform-tools                              | Android SDK Platform-Tools, Revision 29.0.6 |
#### Android SDK Build-Tools
| Package Name                                 | Description                                  |
| -------------------------------------------- | -------------------------------------------- |
| build-tools-30.0.0-rc1                       | Android SDK Build-Tools, Revision 30.0.0 rc1 |
#### Android Utils
| Package Name     | Version          |
| ---------------- | ---------------- |
| Android Emulator | 30.0.0           |
