### PR TITLE
macOS 10.13 Software updates Week 10

### DIFF
--- a/images/macos/macos-10.13-Readme.md
+++ b/images/macos/macos-10.13-Readme.md
@@ -1,11 +1,12 @@
-## OS X info
-- System Version: macOS 10.13.6 (17G11023)
-- Kernel Version: Darwin 17.7.0
-- Boot Volume: Macintosh HD
-- Boot Mode: Normal
-- User Name: runner (runner)
-- Secure Virtual Memory: Enabled
-- System Integrity Protection: Enabled
+# Azure Pipelines hosted macOS image
+
+The following software is installed on machines in the Azure Pipelines **macOS-10.13** VM image ('Hosted macOS High Sierra' pool).
+
+#### Xcode 10.1 set by default
+
+## Operating System
+
+- OS X 10.13.6 (17G11023) **High Sierra**
 
 ## Installed Software
 ### Language and Runtime
@@ -362,20 +363,3 @@
 | Google Play services                            | 49      |
 | Google Repository                               | 58      |
 | Intel x86 Emulator Accelerator (HAXM installer) | 7.5.1   |
-
-## Disk info
-- Total size: 379.2 Gb
-- Free size: 157.84 Gb
-- Used size: 221.36 Gb
-
-## Precache packages
-| Package   | Count | Size   |
-| --------- | ----- | ------ |
-| Nuget     | 418   | 6.69Gb |
-| CocoaPods | 79    | 2.49Gb |
-| Carthage  | 137   | 4.11Gb |
-| Gradle    | 539   | 0.36Gb |
-| Maven     | 120   | 0.11Gb |
-| Npm       | 3862  | 1.16Gb |
-| Yarn      | 1558  | 1.29Gb |
-

--- a/images/macos/macos-10.13-Readme.md
+++ b/images/macos/macos-10.13-Readme.md
@@ -1,12 +1,11 @@
-# Azure Pipelines hosted macOS image
-
-The following software is installed on machines in the Azure Pipelines **macOS-10.13** VM image ('Hosted macOS High Sierra' pool).
-
-#### Xcode 10.1 set by default
-
-## Operating System
-
-- OS X 10.13.6 (17G11023) **High Sierra**
+## OS X info
+- System Version: macOS 10.13.6 (17G11023)
+- Kernel Version: Darwin 17.7.0
+- Boot Volume: Macintosh HD
+- Boot Mode: Normal
+- User Name: runner (runner)
+- Secure Virtual Memory: Enabled
+- System Integrity Protection: Enabled
 
 ## Installed Software
 ### Language and Runtime
@@ -17,21 +16,22 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - Java 13: Zulu13.29+9-CA (build 13.0.2+6-MTS)
 - Node.js v6.17.0
 - NVM 0.33.11
-- NVM - Cached node versions: v6.17.1 v8.17.0 v10.18.1 v12.14.1 v13.7.0
+- NVM - Cached node versions: v6.17.1 v8.17.0 v10.19.0 v12.16.1 v13.9.0
 - PowerShell 6.2.4
 - Python 2.7.17
 - Python 3.7.6
 - Ruby 2.6.5p114
 - .NET SDK 1.0.1 1.0.4 1.1.4 1.1.5 1.1.7 1.1.8 1.1.9 1.1.10 1.1.11 1.1.12 1.1.13 2.0.0 2.0.3 2.1.2 2.1.4 2.1.100 2.1.101 2.1.102 2.1.103 2.1.104 2.1.105 2.1.200 2.1.201 2.1.202 2.1.300 2.1.301 2.1.302 2.1.400 2.1.401 2.1.402 2.1.403 2.1.500 2.1.502 2.1.503 2.1.504 2.1.505 2.2.100 2.2.101 2.2.102 2.2.103 2.2.104 2.2.105
-- Go 1.13.7
+- Go 1.14
+- PHP 7.4.3
 
 ### Package Management
 - Bundler version 2.1.4
 - Carthage 0.34.0
-- CocoaPods 1.8.4
-- Homebrew 2.2.5
+- CocoaPods 1.9.0
+- Homebrew 2.2.6
 - NPM 3.10.10
-- Yarn 1.21.1
+- Yarn 1.22.0
 - NuGet 4.7.0.5148
 - Pip 19.3.1 (python 2.7)
 - Pip 19.3.1 (python 3.7)
@@ -40,7 +40,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 ### Project Management
 - Apache Maven 3.6.3
-- Gradle 6.1.1
+- Gradle 6.2.1
 
 ### Utilities
 - Curl 7.68.0
@@ -48,22 +48,28 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - Git LFS: 2.10.0
 - GNU Wget 1.20.3
 - Subversion (SVN) 1.13.0
-- GNU parallel 20200122
+- GNU parallel 20200222
 - OpenSSL 1.0.2t  10 Sep 2019
 - jq 1.6
 - gpg (GnuPG) 2.2.19
+- psql (PostgreSQL) 12.2
+- aria2 1.35.0
+- azcopy 10.3.4
+- zstd 1.4.4
 
 ### Tools
-- Fastlane 2.141.0
-- Cmake 3.16.3
+- Fastlane 2.142.0
+- Cmake 3.16.4
 - App Center CLI 1.2.2
-- Azure CLI 2.0.80
+- Azure CLI 2.1.0
 
 ### Browsers
-- Google Chrome 79.0.3945.130 
-- ChromeDriver 79.0.3945.36
-- Microsoft Edge 79.0.309.71 
-- MSEdgeDriver 79.0.309.71
+- Google Chrome 80.0.3987.122 
+- ChromeDriver 80.0.3987.106
+- Microsoft Edge 80.0.361.62 
+- MSEdgeDriver 80.0.361.62
+- Mozilla Firefox 73.0.1
+- geckodriver 0.26.0
 
 ### Toolcache
 #### Ruby
@@ -77,7 +83,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - 3.5.9
 - 3.6.10
 - 3.7.6
-- 3.8.1
+- 3.8.2
 
 #### PyPy
 - 2.7.17
@@ -158,19 +164,19 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - NUnit 3.6.1
 
 ### Xcode
-| Version                       | Build                         | Path                          |
-| ----------------------------- | ----------------------------- | ----------------------------- |
-| 10.1 (default)                | 10B61                         | /Applications/Xcode_10.1.app  |
-| 10.0                          | 10A255                        | /Applications/Xcode_10.app    |
-| 9.4.1                         | 9F2000                        | /Applications/Xcode_9.4.1.app |
-| 9.4                           | 9F1027a                       | /Applications/Xcode_9.4.app   |
-| 9.3.1                         | 9E501                         | /Applications/Xcode_9.3.1.app |
-| 9.3                           | 9E145                         | /Applications/Xcode_9.3.app   |
-| 9.2                           | 9C40b                         | /Applications/Xcode_9.2.app   |
-| 9.1                           | 9B55                          | /Applications/Xcode_9.1.app   |
-| 9.0.1                         | 9A1004                        | /Applications/Xcode_9.0.1.app |
-| 9.0                           | 9A235                         | /Applications/Xcode_9.app     |
-| 8.3.3                         | 8E3004b                       | /Applications/Xcode_8.3.3.app |
+| Version        | Build   | Path                          |
+| -------------- | ------- | ----------------------------- |
+| 10.1 (default) | 10B61   | /Applications/Xcode_10.1.app  |
+| 10.0           | 10A255  | /Applications/Xcode_10.app    |
+| 9.4.1          | 9F2000  | /Applications/Xcode_9.4.1.app |
+| 9.4            | 9F1027a | /Applications/Xcode_9.4.app   |
+| 9.3.1          | 9E501   | /Applications/Xcode_9.3.1.app |
+| 9.3            | 9E145   | /Applications/Xcode_9.3.app   |
+| 9.2            | 9C40b   | /Applications/Xcode_9.2.app   |
+| 9.1            | 9B55    | /Applications/Xcode_9.1.app   |
+| 9.0.1          | 9A1004  | /Applications/Xcode_9.0.1.app |
+| 9.0            | 9A235   | /Applications/Xcode_9.app     |
+| 8.3.3          | 8E3004b | /Applications/Xcode_8.3.3.app |
 
 #### Xcode Support Tools
 - Nomad CLI 3.1.2
@@ -180,92 +186,92 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - xcversion 2.6.3
 
 #### Installed SDKs
-| SDK                                          | SDK Name                                     | Xcode Version                                |
-| -------------------------------------------- | -------------------------------------------- | -------------------------------------------- |
-| macOS 10.12                                  | macosx10.12                                  | 8.3.3                                        |
-| macOS 10.13                                  | macosx10.13                                  | 9.0, 9.0.1, 9.1, 9.2, 9.3, 9.3.1, 9.4, 9.4.1 |
-| macOS 10.14                                  | macosx10.14                                  | 10.0, 10.1                                   |
-| iOS 10.3                                     | iphoneos10.3                                 | 8.3.3                                        |
-| iOS 11.0                                     | iphoneos11.0                                 | 9.0, 9.0.1                                   |
-| iOS 11.1                                     | iphoneos11.1                                 | 9.1                                          |
-| iOS 11.2                                     | iphoneos11.2                                 | 9.2                                          |
-| iOS 11.3                                     | iphoneos11.3                                 | 9.3, 9.3.1                                   |
-| iOS 11.4                                     | iphoneos11.4                                 | 9.4, 9.4.1                                   |
-| iOS 12.0                                     | iphoneos12.0                                 | 10.0                                         |
-| iOS 12.1                                     | iphoneos12.1                                 | 10.1                                         |
-| Simulator - iOS 10.3                         | iphonesimulator10.3                          | 8.3.3                                        |
-| Simulator - iOS 11.0                         | iphonesimulator11.0                          | 9.0, 9.0.1                                   |
-| Simulator - iOS 11.1                         | iphonesimulator11.1                          | 9.1                                          |
-| Simulator - iOS 11.2                         | iphonesimulator11.2                          | 9.2                                          |
-| Simulator - iOS 11.3                         | iphonesimulator11.3                          | 9.3, 9.3.1                                   |
-| Simulator - iOS 11.4                         | iphonesimulator11.4                          | 9.4, 9.4.1                                   |
-| Simulator - iOS 12.0                         | iphonesimulator12.0                          | 10.0                                         |
-| Simulator - iOS 12.1                         | iphonesimulator12.1                          | 10.1                                         |
-| tvOS 10.2                                    | appletvos10.2                                | 8.3.3                                        |
-| tvOS 11.0                                    | appletvos11.0                                | 9.0, 9.0.1                                   |
-| tvOS 11.1                                    | appletvos11.1                                | 9.1                                          |
-| tvOS 11.2                                    | appletvos11.2                                | 9.2                                          |
-| tvOS 11.3                                    | appletvos11.3                                | 9.3, 9.3.1                                   |
-| tvOS 11.4                                    | appletvos11.4                                | 9.4, 9.4.1                                   |
-| tvOS 12.0                                    | appletvos12.0                                | 10.0                                         |
-| tvOS 12.1                                    | appletvos12.1                                | 10.1                                         |
-| Simulator - tvOS 10.2                        | appletvsimulator10.2                         | 8.3.3                                        |
-| Simulator - tvOS 11.0                        | appletvsimulator11.0                         | 9.0, 9.0.1                                   |
-| Simulator - tvOS 11.1                        | appletvsimulator11.1                         | 9.1                                          |
-| Simulator - tvOS 11.2                        | appletvsimulator11.2                         | 9.2                                          |
-| Simulator - tvOS 11.3                        | appletvsimulator11.3                         | 9.3, 9.3.1                                   |
-| Simulator - tvOS 11.4                        | appletvsimulator11.4                         | 9.4, 9.4.1                                   |
-| Simulator - tvOS 12.0                        | appletvsimulator12.0                         | 10.0                                         |
-| Simulator - tvOS 12.1                        | appletvsimulator12.1                         | 10.1                                         |
-| watchOS 3.2                                  | watchos3.2                                   | 8.3.3                                        |
-| watchOS 4.0                                  | watchos4.0                                   | 9.0, 9.0.1                                   |
-| watchOS 4.1                                  | watchos4.1                                   | 9.1                                          |
-| watchOS 4.2                                  | watchos4.2                                   | 9.2                                          |
-| watchOS 4.3                                  | watchos4.3                                   | 9.3, 9.3.1, 9.4, 9.4.1                       |
-| watchOS 5.0                                  | watchos5.0                                   | 10.0                                         |
-| watchOS 5.1                                  | watchos5.1                                   | 10.1                                         |
-| Simulator - watchOS 3.2                      | watchsimulator3.2                            | 8.3.3                                        |
-| Simulator - watchOS 4.0                      | watchsimulator4.0                            | 9.0, 9.0.1                                   |
-| Simulator - watchOS 4.1                      | watchsimulator4.1                            | 9.1                                          |
-| Simulator - watchOS 4.2                      | watchsimulator4.2                            | 9.2                                          |
-| Simulator - watchOS 4.3                      | watchsimulator4.3                            | 9.3, 9.3.1, 9.4, 9.4.1                       |
-| Simulator - watchOS 5.0                      | watchsimulator5.0                            | 10.0                                         |
-| Simulator - watchOS 5.1                      | watchsimulator5.1                            | 10.1                                         |
+| SDK                     | SDK Name             | Xcode Version                                |
+| ----------------------- | -------------------- | -------------------------------------------- |
+| macOS 10.12             | macosx10.12          | 8.3.3                                        |
+| macOS 10.13             | macosx10.13          | 9.0, 9.0.1, 9.1, 9.2, 9.3, 9.3.1, 9.4, 9.4.1 |
+| macOS 10.14             | macosx10.14          | 10.0, 10.1                                   |
+| iOS 10.3                | iphoneos10.3         | 8.3.3                                        |
+| iOS 11.0                | iphoneos11.0         | 9.0, 9.0.1                                   |
+| iOS 11.1                | iphoneos11.1         | 9.1                                          |
+| iOS 11.2                | iphoneos11.2         | 9.2                                          |
+| iOS 11.3                | iphoneos11.3         | 9.3, 9.3.1                                   |
+| iOS 11.4                | iphoneos11.4         | 9.4, 9.4.1                                   |
+| iOS 12.0                | iphoneos12.0         | 10.0                                         |
+| iOS 12.1                | iphoneos12.1         | 10.1                                         |
+| Simulator - iOS 10.3    | iphonesimulator10.3  | 8.3.3                                        |
+| Simulator - iOS 11.0    | iphonesimulator11.0  | 9.0, 9.0.1                                   |
+| Simulator - iOS 11.1    | iphonesimulator11.1  | 9.1                                          |
+| Simulator - iOS 11.2    | iphonesimulator11.2  | 9.2                                          |
+| Simulator - iOS 11.3    | iphonesimulator11.3  | 9.3, 9.3.1                                   |
+| Simulator - iOS 11.4    | iphonesimulator11.4  | 9.4, 9.4.1                                   |
+| Simulator - iOS 12.0    | iphonesimulator12.0  | 10.0                                         |
+| Simulator - iOS 12.1    | iphonesimulator12.1  | 10.1                                         |
+| tvOS 10.2               | appletvos10.2        | 8.3.3                                        |
+| tvOS 11.0               | appletvos11.0        | 9.0, 9.0.1                                   |
+| tvOS 11.1               | appletvos11.1        | 9.1                                          |
+| tvOS 11.2               | appletvos11.2        | 9.2                                          |
+| tvOS 11.3               | appletvos11.3        | 9.3, 9.3.1                                   |
+| tvOS 11.4               | appletvos11.4        | 9.4, 9.4.1                                   |
+| tvOS 12.0               | appletvos12.0        | 10.0                                         |
+| tvOS 12.1               | appletvos12.1        | 10.1                                         |
+| Simulator - tvOS 10.2   | appletvsimulator10.2 | 8.3.3                                        |
+| Simulator - tvOS 11.0   | appletvsimulator11.0 | 9.0, 9.0.1                                   |
+| Simulator - tvOS 11.1   | appletvsimulator11.1 | 9.1                                          |
+| Simulator - tvOS 11.2   | appletvsimulator11.2 | 9.2                                          |
+| Simulator - tvOS 11.3   | appletvsimulator11.3 | 9.3, 9.3.1                                   |
+| Simulator - tvOS 11.4   | appletvsimulator11.4 | 9.4, 9.4.1                                   |
+| Simulator - tvOS 12.0   | appletvsimulator12.0 | 10.0                                         |
+| Simulator - tvOS 12.1   | appletvsimulator12.1 | 10.1                                         |
+| watchOS 3.2             | watchos3.2           | 8.3.3                                        |
+| watchOS 4.0             | watchos4.0           | 9.0, 9.0.1                                   |
+| watchOS 4.1             | watchos4.1           | 9.1                                          |
+| watchOS 4.2             | watchos4.2           | 9.2                                          |
+| watchOS 4.3             | watchos4.3           | 9.3, 9.3.1, 9.4, 9.4.1                       |
+| watchOS 5.0             | watchos5.0           | 10.0                                         |
+| watchOS 5.1             | watchos5.1           | 10.1                                         |
+| Simulator - watchOS 3.2 | watchsimulator3.2    | 8.3.3                                        |
+| Simulator - watchOS 4.0 | watchsimulator4.0    | 9.0, 9.0.1                                   |
+| Simulator - watchOS 4.1 | watchsimulator4.1    | 9.1                                          |
+| Simulator - watchOS 4.2 | watchsimulator4.2    | 9.2                                          |
+| Simulator - watchOS 4.3 | watchsimulator4.3    | 9.3, 9.3.1, 9.4, 9.4.1                       |
+| Simulator - watchOS 5.0 | watchsimulator5.0    | 10.0                                         |
+| Simulator - watchOS 5.1 | watchsimulator5.1    | 10.1                                         |
 
 #### Installed Simulators
-| OS                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Xcode Version                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Simulators                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| iOS 8.4                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 8.3.3<br>9.0<br>9.0.1<br>9.1<br>9.2<br>9.3<br>9.3.1<br>9.4<br>9.4.1<br>10.0<br>10.1                                                                                                                                                                                                                                                                                                                                                                            | iPhone 4s<br>iPhone 5<br>iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPad 2<br>iPad Retina<br>iPad Air                                                                                                                                                                                                                                                                                                                                                           |
-| iOS 9.0                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 8.3.3<br>9.0<br>9.0.1<br>9.1<br>9.2<br>9.3<br>9.3.1<br>9.4<br>9.4.1<br>10.0<br>10.1                                                                                                                                                                                                                                                                                                                                                                            | iPhone 4s<br>iPhone 5<br>iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPad 2<br>iPad Retina<br>iPad Air<br>iPad Air 2                                                                                                                                                                                                                                                                                                              |
-| iOS 9.1                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 8.3.3<br>9.0<br>9.0.1<br>9.1<br>9.2<br>9.3<br>9.3.1<br>9.4<br>9.4.1<br>10.0<br>10.1                                                                                                                                                                                                                                                                                                                                                                            | iPhone 4s<br>iPhone 5<br>iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPad 2<br>iPad Retina<br>iPad Air<br>iPad Air 2<br>iPad Pro                                                                                                                                                                                                                                                                                                  |
-| iOS 9.2                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 8.3.3<br>9.0<br>9.0.1<br>9.1<br>9.2<br>9.3<br>9.3.1<br>9.4<br>9.4.1<br>10.0<br>10.1                                                                                                                                                                                                                                                                                                                                                                            | iPhone 4s<br>iPhone 5<br>iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPad 2<br>iPad Retina<br>iPad Air<br>iPad Air 2<br>iPad Pro                                                                                                                                                                                                                                                                                                  |
-| iOS 9.3                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 8.3.3<br>9.0<br>9.0.1<br>9.1<br>9.2<br>9.3<br>9.3.1<br>9.4<br>9.4.1<br>10.0<br>10.1                                                                                                                                                                                                                                                                                                                                                                            | iPhone 4s<br>iPhone 5<br>iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPad 2<br>iPad Retina<br>iPad Air<br>iPad Air 2<br>iPad Pro                                                                                                                                                                                                                                                                                                  |
-| iOS 10.0                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 8.3.3<br>9.0<br>9.0.1<br>9.1<br>9.2<br>9.3<br>9.3.1<br>9.4<br>9.4.1<br>10.0<br>10.1                                                                                                                                                                                                                                                                                                                                                                            | iPhone 5<br>iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone SE<br>iPad Air<br>iPad Air 2<br>iPad Pro (9.7 inch)<br>iPad Pro (12.9 inch)                                                                                                                                                                                                                                                                                        |
-| iOS 10.1                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 8.3.3<br>9.0<br>9.0.1<br>9.1<br>9.2<br>9.3<br>9.3.1<br>9.4<br>9.4.1<br>10.0<br>10.1                                                                                                                                                                                                                                                                                                                                                                            | iPhone 5<br>iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone SE<br>iPad Air<br>iPad Air 2<br>iPad Pro (9.7 inch)<br>iPad Pro (12.9 inch)                                                                                                                                                                                                                                                           |
-| iOS 10.2                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 8.3.3<br>9.0<br>9.0.1<br>9.1<br>9.2<br>9.3<br>9.3.1<br>9.4<br>9.4.1<br>10.0<br>10.1                                                                                                                                                                                                                                                                                                                                                                            | iPhone 5<br>iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone SE<br>iPad Air<br>iPad Air 2<br>iPad Pro (9.7 inch)<br>iPad Pro (12.9 inch)                                                                                                                                                                                                                                                           |
-| iOS 10.3                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 8.3.3                                                                                                                                                                                                                                                                                                                                                                                                                                                          | iPhone 5<br>iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone SE<br>iPad Air<br>iPad Air 2<br>iPad (5th generation)<br>iPad Pro (9.7 inch)<br>iPad Pro (12.9 inch)<br>iPad Pro (12.9-inch) (2nd generation)<br>iPad Pro (10.5-inch)                                                                                                                                                                 |
-| iOS 11.0                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 9.0<br>9.0.1                                                                                                                                                                                                                                                                                                                                                                                                                                                   | iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE<br>iPhone X<br>iPad Air<br>iPad Air 2<br>iPad (5th generation)<br>iPad Pro (9.7-inch)<br>iPad Pro (12.9-inch)<br>iPad Pro (12.9-inch) (2nd generation)<br>iPad Pro (10.5-inch)                                                                                                                                    |
-| iOS 11.1                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 9.1                                                                                                                                                                                                                                                                                                                                                                                                                                                            | iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE<br>iPhone X<br>iPad Air<br>iPad Air 2<br>iPad (5th generation)<br>iPad Pro (9.7-inch)<br>iPad Pro (12.9-inch)<br>iPad Pro (12.9-inch) (2nd generation)<br>iPad Pro (10.5-inch)                                                                                                                                    |
-| iOS 11.2                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 9.2                                                                                                                                                                                                                                                                                                                                                                                                                                                            | iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE<br>iPhone X<br>iPad Air<br>iPad Air 2<br>iPad (5th generation)<br>iPad Pro (9.7-inch)<br>iPad Pro (12.9-inch)<br>iPad Pro (12.9-inch) (2nd generation)<br>iPad Pro (10.5-inch)                                                                                                                                    |
-| iOS 11.3                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 9.3<br>9.3.1                                                                                                                                                                                                                                                                                                                                                                                                                                                   | iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE<br>iPhone X<br>iPad Air<br>iPad Air 2<br>iPad (5th generation)<br>iPad Pro (9.7-inch)<br>iPad Pro (12.9-inch)<br>iPad Pro (12.9-inch) (2nd generation)<br>iPad Pro (10.5-inch)                                                                                                                                    |
-| iOS 11.4                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 9.4<br>9.4.1                                                                                                                                                                                                                                                                                                                                                                                                                                                   | iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE<br>iPhone X<br>iPad Air<br>iPad Air 2<br>iPad (5th generation)<br>iPad Pro (9.7-inch)<br>iPad Pro (12.9-inch)<br>iPad Pro (12.9-inch) (2nd generation)<br>iPad Pro (10.5-inch)                                                                                                                                    |
-| iOS 12.0                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 10.0                                                                                                                                                                                                                                                                                                                                                                                                                                                           | iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE<br>iPhone X<br>iPhone XR<br>iPhone XS<br>iPhone XS Max<br>iPad Air<br>iPad Air 2<br>iPad (5th generation)<br>iPad Pro (9.7-inch)<br>iPad Pro (12.9-inch)<br>iPad Pro (12.9-inch) (2nd generation)<br>iPad Pro (10.5-inch)<br>iPad (6th generation)                                                                |
-| iOS 12.1                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 10.1                                                                                                                                                                                                                                                                                                                                                                                                                                                           | iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE<br>iPhone X<br>iPhone XS<br>iPhone XS Max<br>iPhone XR<br>iPad Air<br>iPad Air 2<br>iPad (5th generation)<br>iPad Pro (9.7-inch)<br>iPad Pro (12.9-inch)<br>iPad Pro (12.9-inch) (2nd generation)<br>iPad Pro (10.5-inch)<br>iPad (6th generation)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation) |
-| tvOS 10.2                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 8.3.3                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Apple TV 1080p                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| tvOS 11.0                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 9.0<br>9.0.1                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                              |
-| tvOS 11.1                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 9.1                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                              |
-| tvOS 11.2                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 9.2                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                              |
-| tvOS 11.3                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 9.3<br>9.3.1                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                              |
-| tvOS 11.4                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 9.4<br>9.4.1                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                              |
-| tvOS 12.0                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 10.0                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                              |
-| tvOS 12.1                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 10.1                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                              |
-| watchOS 3.2                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 8.3.3                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Apple Watch - 38mm<br>Apple Watch - 42mm<br>Apple Watch Series 2 - 38mm<br>Apple Watch Series 2 - 42mm                                                                                                                                                                                                                                                                                                                                                         |
-| watchOS 4.0                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 9.0<br>9.0.1                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Apple Watch - 38mm<br>Apple Watch - 42mm<br>Apple Watch Series 2 - 38mm<br>Apple Watch Series 2 - 42mm<br>Apple Watch Series 3 - 38mm<br>Apple Watch Series 3 - 42mm                                                                                                                                                                                                                                                                                           |
-| watchOS 4.1                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 9.1                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Apple Watch - 38mm<br>Apple Watch - 42mm<br>Apple Watch Series 2 - 38mm<br>Apple Watch Series 2 - 42mm<br>Apple Watch Series 3 - 38mm<br>Apple Watch Series 3 - 42mm                                                                                                                                                                                                                                                                                           |
-| watchOS 4.2                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 9.2                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Apple Watch - 38mm<br>Apple Watch - 42mm<br>Apple Watch Series 2 - 38mm<br>Apple Watch Series 2 - 42mm<br>Apple Watch Series 3 - 38mm<br>Apple Watch Series 3 - 42mm                                                                                                                                                                                                                                                                                           |
-| watchOS 4.3                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 9.3<br>9.3.1<br>9.4<br>9.4.1                                                                                                                                                                                                                                                                                                                                                                                                                                   | Apple Watch - 38mm<br>Apple Watch - 42mm<br>Apple Watch Series 2 - 38mm<br>Apple Watch Series 2 - 42mm<br>Apple Watch Series 3 - 38mm<br>Apple Watch Series 3 - 42mm                                                                                                                                                                                                                                                                                           |
-| watchOS 5.0                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 10.0                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Apple Watch Series 2 - 38mm<br>Apple Watch Series 2 - 42mm<br>Apple Watch Series 3 - 38mm<br>Apple Watch Series 3 - 42mm<br>Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm                                                                                                                                                                                                                                                                         |
-| watchOS 5.1                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 10.1                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Apple Watch Series 2 - 38mm<br>Apple Watch Series 2 - 42mm<br>Apple Watch Series 3 - 38mm<br>Apple Watch Series 3 - 42mm<br>Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm                                                                                                                                                                                                                                                                         |
+| OS          | Xcode Version                                                                       | Simulators                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ----------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| iOS 8.4     | 8.3.3<br>9.0<br>9.0.1<br>9.1<br>9.2<br>9.3<br>9.3.1<br>9.4<br>9.4.1<br>10.0<br>10.1 | iPhone 4s<br>iPhone 5<br>iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPad 2<br>iPad Retina<br>iPad Air                                                                                                                                                                                                                                                                                                                                                           |
+| iOS 9.0     | 8.3.3<br>9.0<br>9.0.1<br>9.1<br>9.2<br>9.3<br>9.3.1<br>9.4<br>9.4.1<br>10.0<br>10.1 | iPhone 4s<br>iPhone 5<br>iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPad 2<br>iPad Retina<br>iPad Air<br>iPad Air 2                                                                                                                                                                                                                                                                                                              |
+| iOS 9.1     | 8.3.3<br>9.0<br>9.0.1<br>9.1<br>9.2<br>9.3<br>9.3.1<br>9.4<br>9.4.1<br>10.0<br>10.1 | iPhone 4s<br>iPhone 5<br>iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPad 2<br>iPad Retina<br>iPad Air<br>iPad Air 2<br>iPad Pro                                                                                                                                                                                                                                                                                                  |
+| iOS 9.2     | 8.3.3<br>9.0<br>9.0.1<br>9.1<br>9.2<br>9.3<br>9.3.1<br>9.4<br>9.4.1<br>10.0<br>10.1 | iPhone 4s<br>iPhone 5<br>iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPad 2<br>iPad Retina<br>iPad Air<br>iPad Air 2<br>iPad Pro                                                                                                                                                                                                                                                                                                  |
+| iOS 9.3     | 8.3.3<br>9.0<br>9.0.1<br>9.1<br>9.2<br>9.3<br>9.3.1<br>9.4<br>9.4.1<br>10.0<br>10.1 | iPhone 4s<br>iPhone 5<br>iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPad 2<br>iPad Retina<br>iPad Air<br>iPad Air 2<br>iPad Pro                                                                                                                                                                                                                                                                                                  |
+| iOS 10.0    | 8.3.3<br>9.0<br>9.0.1<br>9.1<br>9.2<br>9.3<br>9.3.1<br>9.4<br>9.4.1<br>10.0<br>10.1 | iPhone 5<br>iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone SE<br>iPad Air<br>iPad Air 2<br>iPad Pro (9.7 inch)<br>iPad Pro (12.9 inch)                                                                                                                                                                                                                                                                                        |
+| iOS 10.1    | 8.3.3<br>9.0<br>9.0.1<br>9.1<br>9.2<br>9.3<br>9.3.1<br>9.4<br>9.4.1<br>10.0<br>10.1 | iPhone 5<br>iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone SE<br>iPad Air<br>iPad Air 2<br>iPad Pro (9.7 inch)<br>iPad Pro (12.9 inch)                                                                                                                                                                                                                                                           |
+| iOS 10.2    | 8.3.3<br>9.0<br>9.0.1<br>9.1<br>9.2<br>9.3<br>9.3.1<br>9.4<br>9.4.1<br>10.0<br>10.1 | iPhone 5<br>iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone SE<br>iPad Air<br>iPad Air 2<br>iPad Pro (9.7 inch)<br>iPad Pro (12.9 inch)                                                                                                                                                                                                                                                           |
+| iOS 10.3    | 8.3.3                                                                               | iPhone 5<br>iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone SE<br>iPad Air<br>iPad Air 2<br>iPad (5th generation)<br>iPad Pro (9.7 inch)<br>iPad Pro (12.9 inch)<br>iPad Pro (12.9-inch) (2nd generation)<br>iPad Pro (10.5-inch)                                                                                                                                                                 |
+| iOS 11.0    | 9.0<br>9.0.1                                                                        | iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone SE<br>iPhone 8<br>iPhone 8 Plus<br>iPhone X<br>iPad Air<br>iPad Air 2<br>iPad (5th generation)<br>iPad Pro (9.7-inch)<br>iPad Pro (12.9-inch)<br>iPad Pro (12.9-inch) (2nd generation)<br>iPad Pro (10.5-inch)                                                                                                                                    |
+| iOS 11.1    | 9.1                                                                                 | iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE<br>iPhone X<br>iPad Air<br>iPad Air 2<br>iPad (5th generation)<br>iPad Pro (9.7-inch)<br>iPad Pro (12.9-inch)<br>iPad Pro (12.9-inch) (2nd generation)<br>iPad Pro (10.5-inch)                                                                                                                                    |
+| iOS 11.2    | 9.2                                                                                 | iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE<br>iPhone X<br>iPad Air<br>iPad Air 2<br>iPad (5th generation)<br>iPad Pro (9.7-inch)<br>iPad Pro (12.9-inch)<br>iPad Pro (12.9-inch) (2nd generation)<br>iPad Pro (10.5-inch)                                                                                                                                    |
+| iOS 11.3    | 9.3<br>9.3.1                                                                        | iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE<br>iPhone X<br>iPad Air<br>iPad Air 2<br>iPad (5th generation)<br>iPad Pro (9.7-inch)<br>iPad Pro (12.9-inch)<br>iPad Pro (12.9-inch) (2nd generation)<br>iPad Pro (10.5-inch)                                                                                                                                    |
+| iOS 11.4    | 9.4<br>9.4.1                                                                        | iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE<br>iPhone X<br>iPad Air<br>iPad Air 2<br>iPad (5th generation)<br>iPad Pro (9.7-inch)<br>iPad Pro (12.9-inch)<br>iPad Pro (12.9-inch) (2nd generation)<br>iPad Pro (10.5-inch)                                                                                                                                    |
+| iOS 12.0    | 10.0                                                                                | iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE<br>iPhone X<br>iPhone XR<br>iPhone XS<br>iPhone XS Max<br>iPad Air<br>iPad Air 2<br>iPad (5th generation)<br>iPad Pro (9.7-inch)<br>iPad Pro (12.9-inch)<br>iPad Pro (12.9-inch) (2nd generation)<br>iPad Pro (10.5-inch)<br>iPad (6th generation)                                                                |
+| iOS 12.1    | 10.1                                                                                | iPhone 5s<br>iPhone 6<br>iPhone 6 Plus<br>iPhone 6s<br>iPhone 6s Plus<br>iPhone 7<br>iPhone 7 Plus<br>iPhone 8<br>iPhone 8 Plus<br>iPhone SE<br>iPhone X<br>iPhone XS<br>iPhone XS Max<br>iPhone XR<br>iPad Air<br>iPad Air 2<br>iPad (5th generation)<br>iPad Pro (9.7-inch)<br>iPad Pro (12.9-inch)<br>iPad Pro (12.9-inch) (2nd generation)<br>iPad Pro (10.5-inch)<br>iPad (6th generation)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation) |
+| tvOS 10.2   | 8.3.3                                                                               | Apple TV 1080p                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| tvOS 11.0   | 9.0<br>9.0.1                                                                        | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                              |
+| tvOS 11.1   | 9.1                                                                                 | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                              |
+| tvOS 11.2   | 9.2                                                                                 | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                              |
+| tvOS 11.3   | 9.3<br>9.3.1                                                                        | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                              |
+| tvOS 11.4   | 9.4<br>9.4.1                                                                        | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                              |
+| tvOS 12.0   | 10.0                                                                                | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                              |
+| tvOS 12.1   | 10.1                                                                                | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                                                                                                                                                                                                                              |
+| watchOS 3.2 | 8.3.3                                                                               | Apple Watch - 38mm<br>Apple Watch - 42mm<br>Apple Watch Series 2 - 38mm<br>Apple Watch Series 2 - 42mm                                                                                                                                                                                                                                                                                                                                                         |
+| watchOS 4.0 | 9.0<br>9.0.1                                                                        | Apple Watch - 38mm<br>Apple Watch - 42mm<br>Apple Watch Series 2 - 38mm<br>Apple Watch Series 2 - 42mm<br>Apple Watch Series 3 - 38mm<br>Apple Watch Series 3 - 42mm                                                                                                                                                                                                                                                                                           |
+| watchOS 4.1 | 9.1                                                                                 | Apple Watch - 38mm<br>Apple Watch - 42mm<br>Apple Watch Series 2 - 38mm<br>Apple Watch Series 2 - 42mm<br>Apple Watch Series 3 - 38mm<br>Apple Watch Series 3 - 42mm                                                                                                                                                                                                                                                                                           |
+| watchOS 4.2 | 9.2                                                                                 | Apple Watch - 38mm<br>Apple Watch - 42mm<br>Apple Watch Series 2 - 38mm<br>Apple Watch Series 2 - 42mm<br>Apple Watch Series 3 - 38mm<br>Apple Watch Series 3 - 42mm                                                                                                                                                                                                                                                                                           |
+| watchOS 4.3 | 9.3<br>9.3.1<br>9.4<br>9.4.1                                                        | Apple Watch - 38mm<br>Apple Watch - 42mm<br>Apple Watch Series 2 - 38mm<br>Apple Watch Series 2 - 42mm<br>Apple Watch Series 3 - 38mm<br>Apple Watch Series 3 - 42mm                                                                                                                                                                                                                                                                                           |
+| watchOS 5.0 | 10.0                                                                                | Apple Watch Series 2 - 38mm<br>Apple Watch Series 2 - 42mm<br>Apple Watch Series 3 - 38mm<br>Apple Watch Series 3 - 42mm<br>Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm                                                                                                                                                                                                                                                                         |
+| watchOS 5.1 | 10.1                                                                                | Apple Watch Series 2 - 38mm<br>Apple Watch Series 2 - 42mm<br>Apple Watch Series 3 - 38mm<br>Apple Watch Series 3 - 42mm<br>Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm                                                                                                                                                                                                                                                                         |
 
 ### Android
 #### Android SDK Tools
@@ -274,84 +280,102 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | tools                              | Android SDK Tools, Revision 26.1.1 |
 
 #### Android SDK Platform-Tools
-| Package Name                                | Description                                 |
-| ------------------------------------------- | ------------------------------------------- |
-| platform-tools                              | Android SDK Platform-Tools, Revision 29.0.5 |
+| Package Name   | Description                                 |
+| -------------- | ------------------------------------------- |
+| platform-tools | Android SDK Platform-Tools, Revision 29.0.6 |
 
 #### Android SDK Platforms
-| Package Name                        | Description                         |
-| ----------------------------------- | ----------------------------------- |
-| android-15                          | Android SDK Platform 15, Revision 5 |
-| android-16                          | Android SDK Platform 16, Revision 5 |
-| android-17                          | Android SDK Platform 17, Revision 3 |
-| android-18                          | Android SDK Platform 18, Revision 3 |
-| android-19                          | Android SDK Platform 19, Revision 4 |
-| android-20                          | Android SDK Platform 20, Revision 2 |
-| android-21                          | Android SDK Platform 21, Revision 2 |
-| android-22                          | Android SDK Platform 22, Revision 2 |
-| android-23                          | Android SDK Platform 23, Revision 3 |
-| android-24                          | Android SDK Platform 24, Revision 2 |
-| android-25                          | Android SDK Platform 25, Revision 3 |
-| android-26                          | Android SDK Platform 26, Revision 2 |
-| android-27                          | Android SDK Platform 27, Revision 3 |
-| android-28                          | Android SDK Platform 28, Revision 6 |
-| android-29                          | Android SDK Platform 29, Revision 4 |
+| Package Name | Description                         |
+| ------------ | ----------------------------------- |
+| android-15   | Android SDK Platform 15, Revision 5 |
+| android-16   | Android SDK Platform 16, Revision 5 |
+| android-17   | Android SDK Platform 17, Revision 3 |
+| android-18   | Android SDK Platform 18, Revision 3 |
+| android-19   | Android SDK Platform 19, Revision 4 |
+| android-20   | Android SDK Platform 20, Revision 2 |
+| android-21   | Android SDK Platform 21, Revision 2 |
+| android-22   | Android SDK Platform 22, Revision 2 |
+| android-23   | Android SDK Platform 23, Revision 3 |
+| android-24   | Android SDK Platform 24, Revision 2 |
+| android-25   | Android SDK Platform 25, Revision 3 |
+| android-26   | Android SDK Platform 26, Revision 2 |
+| android-27   | Android SDK Platform 27, Revision 3 |
+| android-28   | Android SDK Platform 28, Revision 6 |
+| android-29   | Android SDK Platform 29, Revision 4 |
 
 #### Android SDK Build-Tools
-| Package Name                             | Description                              |
-| ---------------------------------------- | ---------------------------------------- |
-| build-tools-19.1.0                       | Android SDK Build-Tools, Revision 19.1.0 |
-| build-tools-20.0.0                       | Android SDK Build-Tools, Revision 20.0.0 |
-| build-tools-21.1.2                       | Android SDK Build-Tools, Revision 21.1.2 |
-| build-tools-22.0.1                       | Android SDK Build-Tools, Revision 22.0.1 |
-| build-tools-23.0.1                       | Android SDK Build-Tools, Revision 23.0.1 |
-| build-tools-23.0.2                       | Android SDK Build-Tools, Revision 23.0.2 |
-| build-tools-23.0.3                       | Android SDK Build-Tools, Revision 23.0.3 |
-| build-tools-24.0.0                       | Android SDK Build-Tools, Revision 24.0.0 |
-| build-tools-24.0.1                       | Android SDK Build-Tools, Revision 24.0.1 |
-| build-tools-24.0.2                       | Android SDK Build-Tools, Revision 24.0.2 |
-| build-tools-24.0.3                       | Android SDK Build-Tools, Revision 24.0.3 |
-| build-tools-25.0.0                       | Android SDK Build-Tools, Revision 25.0.0 |
-| build-tools-25.0.1                       | Android SDK Build-Tools, Revision 25.0.1 |
-| build-tools-25.0.2                       | Android SDK Build-Tools, Revision 25.0.2 |
-| build-tools-25.0.3                       | Android SDK Build-Tools, Revision 25.0.3 |
-| build-tools-26.0.0                       | Android SDK Build-Tools, Revision 26.0.0 |
-| build-tools-26.0.1                       | Android SDK Build-Tools, Revision 26.0.1 |
-| build-tools-26.0.2                       | Android SDK Build-Tools, Revision 26.0.2 |
-| build-tools-26.0.3                       | Android SDK Build-Tools, Revision 26.0.3 |
-| build-tools-27.0.0                       | Android SDK Build-Tools, Revision 27.0.0 |
-| build-tools-27.0.1                       | Android SDK Build-Tools, Revision 27.0.1 |
-| build-tools-27.0.2                       | Android SDK Build-Tools, Revision 27.0.2 |
-| build-tools-27.0.3                       | Android SDK Build-Tools, Revision 27.0.3 |
-| build-tools-28.0.0                       | Android SDK Build-Tools, Revision 28.0.0 |
-| build-tools-28.0.1                       | Android SDK Build-Tools, Revision 28.0.1 |
-| build-tools-28.0.2                       | Android SDK Build-Tools, Revision 28.0.2 |
-| build-tools-28.0.3                       | Android SDK Build-Tools, Revision 28.0.3 |
-| build-tools-29.0.0                       | Android SDK Build-Tools, Revision 29.0.0 |
-| build-tools-29.0.1                       | Android SDK Build-Tools, Revision 29.0.1 |
-| build-tools-29.0.2                       | Android SDK Build-Tools, Revision 29.0.2 |
-| build-tools-29.0.3                       | Android SDK Build-Tools, Revision 29.0.3 |
+| Package Name           | Description                                  |
+| ---------------------- | -------------------------------------------- |
+| build-tools-19.1.0     | Android SDK Build-Tools, Revision 19.1.0     |
+| build-tools-20.0.0     | Android SDK Build-Tools, Revision 20.0.0     |
+| build-tools-21.1.2     | Android SDK Build-Tools, Revision 21.1.2     |
+| build-tools-22.0.1     | Android SDK Build-Tools, Revision 22.0.1     |
+| build-tools-23.0.1     | Android SDK Build-Tools, Revision 23.0.1     |
+| build-tools-23.0.2     | Android SDK Build-Tools, Revision 23.0.2     |
+| build-tools-23.0.3     | Android SDK Build-Tools, Revision 23.0.3     |
+| build-tools-24.0.0     | Android SDK Build-Tools, Revision 24.0.0     |
+| build-tools-24.0.1     | Android SDK Build-Tools, Revision 24.0.1     |
+| build-tools-24.0.2     | Android SDK Build-Tools, Revision 24.0.2     |
+| build-tools-24.0.3     | Android SDK Build-Tools, Revision 24.0.3     |
+| build-tools-25.0.0     | Android SDK Build-Tools, Revision 25.0.0     |
+| build-tools-25.0.1     | Android SDK Build-Tools, Revision 25.0.1     |
+| build-tools-25.0.2     | Android SDK Build-Tools, Revision 25.0.2     |
+| build-tools-25.0.3     | Android SDK Build-Tools, Revision 25.0.3     |
+| build-tools-26.0.0     | Android SDK Build-Tools, Revision 26.0.0     |
+| build-tools-26.0.1     | Android SDK Build-Tools, Revision 26.0.1     |
+| build-tools-26.0.2     | Android SDK Build-Tools, Revision 26.0.2     |
+| build-tools-26.0.3     | Android SDK Build-Tools, Revision 26.0.3     |
+| build-tools-27.0.0     | Android SDK Build-Tools, Revision 27.0.0     |
+| build-tools-27.0.1     | Android SDK Build-Tools, Revision 27.0.1     |
+| build-tools-27.0.2     | Android SDK Build-Tools, Revision 27.0.2     |
+| build-tools-27.0.3     | Android SDK Build-Tools, Revision 27.0.3     |
+| build-tools-28.0.0     | Android SDK Build-Tools, Revision 28.0.0     |
+| build-tools-28.0.1     | Android SDK Build-Tools, Revision 28.0.1     |
+| build-tools-28.0.2     | Android SDK Build-Tools, Revision 28.0.2     |
+| build-tools-28.0.3     | Android SDK Build-Tools, Revision 28.0.3     |
+| build-tools-29.0.0     | Android SDK Build-Tools, Revision 29.0.0     |
+| build-tools-29.0.1     | Android SDK Build-Tools, Revision 29.0.1     |
+| build-tools-29.0.2     | Android SDK Build-Tools, Revision 29.0.2     |
+| build-tools-29.0.3     | Android SDK Build-Tools, Revision 29.0.3     |
+| build-tools-30.0.0-rc1 | Android SDK Build-Tools, Revision 30.0.0 rc1 |
 
 #### Android Utils
-| Package Name     | Version          |
-| ---------------- | ---------------- |
-| cmake            | 3.6.4111459      |
-| lldb             | 3.1.4508709      |
-| ndk-bundle       | 18.1.5063045     |
-| Android Emulator | 29.3.4           |
+| Package Name     | Version      |
+| ---------------- | ------------ |
+| cmake            | 3.6.4111459  |
+| lldb             | 3.1.4508709  |
+| ndk-bundle       | 18.1.5063045 |
+| Android Emulator | 30.0.0       |
 
 #### Android Google APIs
-| Package Name                | Description                 |
-| --------------------------- | --------------------------- |
-| addon-google_apis-google-21 | Google APIs, Revision 1     |
-| addon-google_apis-google-22 | Google APIs, Revision 1     |
-| addon-google_apis-google-23 | Google APIs, Revision 1     |
-| addon-google_apis-google-24 | Google APIs, Revision 1     |
+| Package Name                | Description             |
+| --------------------------- | ----------------------- |
+| addon-google_apis-google-21 | Google APIs, Revision 1 |
+| addon-google_apis-google-22 | Google APIs, Revision 1 |
+| addon-google_apis-google-23 | Google APIs, Revision 1 |
+| addon-google_apis-google-24 | Google APIs, Revision 1 |
 
 #### Extra Packages
-| Package Name                                    | Version                                         |
-| ----------------------------------------------- | ----------------------------------------------- |
-| Android Support Repository                      | 47.0.0                                          |
-| Google Play services                            | 49                                              |
-| Google Repository                               | 58                                              |
-| Intel x86 Emulator Accelerator (HAXM installer) | 7.5.1                                           |
+| Package Name                                    | Version |
+| ----------------------------------------------- | ------- |
+| Android Support Repository                      | 47.0.0  |
+| Google Play services                            | 49      |
+| Google Repository                               | 58      |
+| Intel x86 Emulator Accelerator (HAXM installer) | 7.5.1   |
+
+## Disk info
+- Total size: 379.2 Gb
+- Free size: 157.84 Gb
+- Used size: 221.36 Gb
+
+## Precache packages
+| Package   | Count | Size   |
+| --------- | ----- | ------ |
+| Nuget     | 418   | 6.69Gb |
+| CocoaPods | 79    | 2.49Gb |
+| Carthage  | 137   | 4.11Gb |
+| Gradle    | 539   | 0.36Gb |
+| Maven     | 120   | 0.11Gb |
+| Npm       | 3862  | 1.16Gb |
+| Yarn      | 1558  | 1.29Gb |
+


### PR DESCRIPTION
Software updates:
- NVM - Cached node versions: v10.19.0 v12.16.1 v13.9.0
- Go 1.14
- PHP 7.4.3
- CocoaPods 1.9.0
- Homebrew 2.2.6
- Yarn 1.22.0
- Gradle 6.2.1
- GNU parallel 20200222
- psql (PostgreSQL) 12.2
- aria2 1.35.0
- azcopy 10.3.4
- zstd 1.4.4
- Fastlane 2.142.0
- Cmake 3.16.4
- Azure CLI 2.1.0
- Google Chrome 80.0.3987.122 
- ChromeDriver 80.0.3987.106
- Microsoft Edge 80.0.361.62 
- MSEdgeDriver 80.0.361.62
- Mozilla Firefox 73.0.1
- geckodriver 0.26.0
- Python 3.8.2
- Android SDK Build-Tools, Revision 30.0.0 rc1