### PR TITLE
macos 10.14 software updates week 12

### DIFF
--- a/images/macos/macos-10.14-Readme.md
+++ b/images/macos/macos-10.14-Readme.md
@@ -14,18 +14,18 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - Java 11: Zulu11.37+17-CA (build 11.0.6+10-LTS)
 - Java 12: Zulu12.3+11-CA (build 12.0.2+3)
 - Java 13: Zulu13.29+9-CA (build 13.0.2+6-MTS)
-- Rust 1.41.1
+- Rust 1.42.0
 - Clang/LLVM 9.0.1
-- gcc-8 (Homebrew GCC 8.3.0_2) 8.3.0
-- gcc-9 (Homebrew GCC 9.2.0_3) 9.2.0
-- GNU Fortran (Homebrew GCC 8.3.0_2) 8.3.0
-- GNU Fortran (Homebrew GCC 9.2.0_3) 9.2.0
+- gcc-8 (Homebrew GCC 8.4.0) 8.4.0
+- gcc-9 (Homebrew GCC 9.3.0) 9.3.0
+- GNU Fortran (Homebrew GCC 8.4.0) 8.4.0
+- GNU Fortran (Homebrew GCC 9.3.0) 9.3.0
 - Node.js v6.17.0
 - NVM 0.33.11
-- NVM - Cached node versions: v6.17.1 v8.17.0 v10.19.0 v12.16.1 v13.10.1
+- NVM - Cached node versions: v6.17.1 v8.17.0 v10.19.0 v12.16.1 v13.11.0
 - PowerShell 7.0.0
 - Python 2.7.17
-- Python 3.7.6
+- Python 3.7.7
 - Ruby 2.6.5p114
 - .NET SDK 1.0.1 1.0.4 1.1.4 1.1.5 1.1.7 1.1.8 1.1.9 1.1.10 1.1.11 1.1.12 1.1.13 2.0.0 2.0.3 2.1.2 2.1.4 2.1.100 2.1.101 2.1.102 2.1.103 2.1.104 2.1.105 2.1.200 2.1.201 2.1.202 2.1.300 2.1.301 2.1.302 2.1.400 2.1.401 2.1.402 2.1.403 2.1.500 2.1.502 2.1.503 2.1.504 2.1.505 2.2.100 2.2.101 2.2.102 2.2.103 2.2.104 2.2.105
 - Go 1.14
@@ -34,17 +34,16 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 ### Package Management
 - Rustup 1.21.1
-- Vcpkg 2020.02.04
 - Bundler version 2.1.4
 - Carthage 0.34.0
-- CocoaPods 1.9.0
-- Homebrew 2.2.9
+- CocoaPods 1.9.1
+- Homebrew 2.2.10
 - NPM 3.10.10
-- Yarn 1.22.1
+- Yarn 1.22.4
 - NuGet 4.7.0.5148
 - Pip 19.3.1 (python 2.7)
-- Pip 19.3.1 (python 3.7)
-- Miniconda 4.7.12
+- Pip 20.0.2 (python 3.7)
+- Miniconda 4.8.2
 - RubyGems 3.1.2
 
 ### Project Management
@@ -52,9 +51,10 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - Gradle 6.2.2
 
 ### Utilities
-- Curl 7.69.0
-- Git: 2.25.0
+- Curl 7.69.1
+- Git: 2.25.1
 - Git LFS: 2.10.0
+- Hub CLI: 2.14.2
 - GNU Wget 1.20.3
 - Subversion (SVN) 1.13.0
 - Packer 1.5.4
@@ -73,14 +73,14 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - Fastlane 2.143.0
 - Cmake 3.16.5
 - App Center CLI 1.2.2
-- Azure CLI 2.1.0
+- Azure CLI 2.2.0
 
 ### Browsers
-- Google Chrome 80.0.3987.132
+- Google Chrome 80.0.3987.132 
 - ChromeDriver 80.0.3987.106
-- Microsoft Edge 80.0.361.66
+- Microsoft Edge 80.0.361.66 
 - MSEdgeDriver 80.0.361.66
-- Mozilla Firefox 73.0.1
+- Mozilla Firefox 74.0
 - geckodriver 0.26.0
 
 ### Toolcache
@@ -383,5 +383,6 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | Google Play services                            | 49      |
 | Google Repository                               | 58      |
 | Intel x86 Emulator Accelerator (HAXM installer) | 7.5.1   |
+
 
 

--- a/images/macos/macos-10.14-Readme.md
+++ b/images/macos/macos-10.14-Readme.md
@@ -385,4 +385,3 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | Intel x86 Emulator Accelerator (HAXM installer) | 7.5.1   |
 
 
-


### PR DESCRIPTION
## Installed Software
### Language and Runtime
- Rust 1.42.0
- gcc-8 (Homebrew GCC 8.4.0) 8.4.0
- gcc-9 (Homebrew GCC 9.3.0) 9.3.0
- GNU Fortran (Homebrew GCC 8.4.0) 8.4.0
- GNU Fortran (Homebrew GCC 9.3.0) 9.3.0
- NVM - Cached node versions: v13.11.0
- Python 3.7.7

### Package Management
- CocoaPods 1.9.1
- Homebrew 2.2.9	- Homebrew 2.2.10
- Yarn 1.22.4
- Pip 20.0.2 (python 3.7)
- Miniconda 4.8.2

### Utilities
- Curl 7.69.1
- Git: 2.25.1
- Hub CLI: 2.14.2
- Azure CLI 2.2.0

### Browsers
- Google Chrome 80.0.3987.132 
- Microsoft Edge 80.0.361.66 
- Mozilla Firefox 74.0