### PR TITLE
macOS 10.15 Software Updates Week 14

### DIFF
--- a/images/macos/macos-10.15-Readme.md
+++ b/images/macos/macos-10.15-Readme.md
@@ -5,7 +5,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 #### Xcode 11.3.1 set by default
 
 ## Operating System
-- OS X 10.15.3 (19D76) **Catalina**
+- OS X 10.15.4 (19E266) **Catalina**
 
 ## Installed Software
 ### Language and Runtime
@@ -14,6 +14,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - Java 11: Zulu11.37+17-CA (build 11.0.6+10-LTS)
 - Java 12: Zulu12.3+11-CA (build 12.0.2+3)
 - Java 13: Zulu13.29+9-CA (build 13.0.2+6-MTS)
+- Java 14: Zulu14.27+1-CA (build 14+36)
 - Rust 1.42.0
 - Clang/LLVM 9.0.1
 - gcc-8 (Homebrew GCC 8.4.0) 8.4.0
@@ -22,15 +23,15 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - GNU Fortran (Homebrew GCC 9.3.0) 9.3.0
 - Node.js v12.16.1
 - NVM 0.33.11
-- NVM - Cached node versions: v6.17.1 v8.17.0 v10.19.0 v12.16.1 v13.11.0
+- NVM - Cached node versions: v6.17.1 v8.17.0 v10.19.0 v12.16.1 v13.12.0
 - PowerShell 7.0.0
 - Python 2.7.17
 - Python 3.7.7
 - Ruby 2.6.5p114
-- .NET SDK 2.0.0 3.0.100 3.0.101 3.0.102 3.0.103 3.1.100 3.1.101
-- Go 1.14
-- PHP 7.4.3
-- julia 1.3.1
+- .NET SDK 2.0.0 3.0.100 3.0.101 3.0.102 3.0.103 3.1.100 3.1.101 3.1.200 3.1.201
+- Go 1.14.1
+- PHP 7.4.4
+- julia 1.4.0
 
 ### Package Management
 - Rustup 1.21.1
@@ -38,10 +39,10 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - Bundler version 2.1.4
 - Carthage 0.34.0
 - CocoaPods 1.9.1
-- Homebrew 2.2.10
+- Homebrew 2.2.11
 - NPM 6.13.4
 - Yarn 1.22.4
-- NuGet 5.4.0.6315
+- NuGet 5.5.0.6382
 - Pip 19.3.1 (python 2.7)
 - Pip 20.0.2 (python 3.7)
 - Miniconda 4.8.2
@@ -49,38 +50,43 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 ### Project Management
 - Apache Maven 3.6.3
-- Gradle 6.2.2
+- Gradle 6.3
 
 ### Utilities
 - Curl 7.69.1
-- Git: 2.25.1
+- Git: 2.26.0
 - Git LFS: 2.10.0
 - Hub CLI: 2.14.2
 - GNU Wget 1.20.3
 - Subversion (SVN) 1.13.0
-- Packer 1.5.4
-- GNU parallel 20200222
+- Packer 1.5.5
+- GNU parallel 20200322
 - OpenSSL 1.0.2t  10 Sep 2019
 - jq 1.6
-- gpg (GnuPG) 2.2.19
+- gpg (GnuPG) 2.2.20
 - psql (PostgreSQL) 12.2
 - aria2 1.35.0
 - azcopy 10.3.4
 - zstd 1.4.4
 - bazel 2.2.0
 - bazelisk v1.3.0
+- helm v3.1.2+gd878d4d
+- Docker 19.03.8
+- docker-machine 0.16.2
+- docker-compose 1.25.4
 
 ### Tools
-- Fastlane 2.143.0
-- Cmake 3.16.5
-- App Center CLI 2.3.4
+- Fastlane 2.144.0
+- Cmake 3.17.0
+- App Center CLI 2.3.5
 - Azure CLI 2.2.0
+- AWS CLI 2.0.5
 
 ### Browsers
-- Google Chrome 80.0.3987.132
+- Google Chrome 80.0.3987.149 
 - ChromeDriver 80.0.3987.106
-- Microsoft Edge 80.0.361.66
-- MSEdgeDriver 80.0.361.66
+- Microsoft Edge 80.0.361.69 
+- MSEdgeDriver 80.0.361.69
 - Mozilla Firefox 74.0
 - geckodriver 0.26.0
 
@@ -104,25 +110,29 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 
 ### Xamarin
 #### Visual Studio for Mac
-- 8.4.8.2
+- 8.5.0.3183
 
 #### Mono
+- 6.8.0.123
 - 6.6.0.166
 - 6.4.0.208
 
 #### Xamarin.iOS
+- 13.14.1.39
 - 13.10.0.21
 - 13.8.3.0
 - 13.6.0.12
 - 13.4.0.2
 
 #### Xamarin.Mac
+- 6.14.1.39
 - 6.10.0.21
 - 6.8.3.0
 - 6.6.0.12
 - 6.4.0.2
 
 #### Xamarin.Android
+- 10.2.0
 - 10.1.3
 - 10.0.6
 
@@ -130,15 +140,15 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 - NUnit 3.6.1
 
 ### Xcode
-| Version          | Build   | Path                              |
-| ---------------- | ------- | --------------------------------- |
-| 11.4 (beta)      | 11N132i | /Applications/Xcode_11.4_beta.app |
-| 11.3.1 (default) | 11C505  | /Applications/Xcode_11.3.1.app    |
-| 11.3             | 11C29   | /Applications/Xcode_11.3.app      |
-| 11.2.1           | 11B500  | /Applications/Xcode_11.2.1.app    |
-| 11.2             | 11B52   | /Applications/Xcode_11.2.app      |
-| 11.1             | 11A1027 | /Applications/Xcode_11.1.app      |
-| 11.0             | 11A420a | /Applications/Xcode_11.app        |
+| Version          | Build   | Path                           |
+| ---------------- | ------- | ------------------------------ |
+| 11.4             | 11E146  | /Applications/Xcode_11.4.app   |
+| 11.3.1 (default) | 11C505  | /Applications/Xcode_11.3.1.app |
+| 11.3             | 11C29   | /Applications/Xcode_11.3.app   |
+| 11.2.1           | 11B500  | /Applications/Xcode_11.2.1.app |
+| 11.2             | 11B52   | /Applications/Xcode_11.2.app   |
+| 11.1             | 11A1027 | /Applications/Xcode_11.1.app   |
+| 11.0             | 11A420a | /Applications/Xcode_11.app     |
 
 #### Xcode Support Tools
 - Nomad CLI 3.1.2
@@ -174,20 +184,20 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | DriverKit 19.0          | driverkit.macosx19.0 | 11.0, 11.1, 11.2, 11.2.1, 11.3, 11.3.1, 11.4 |
 
 #### Installed Simulators
-| OS          | Xcode Version                    | Simulators                                                                                                                                                                                                               |
-| ----------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| iOS 13.0    | 11.0                             | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                          |
-| iOS 13.1    | 11.1                             | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                          |
-| iOS 13.2    | 11.2<br>11.2.1                   | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                          |
-| iOS 13.3    | 11.3<br>11.3.1                   | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad (7th generation)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation) |
-| iOS 13.4    | 11.4                             | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad (7th generation)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation) |
-| tvOS 13.0   | 11.0<br>11.1                     | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                        |
-| tvOS 13.2   | 11.2<br>11.2.1                   | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                        |
-| tvOS 13.3   | 11.3<br>11.3.1                   | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                        |
-| tvOS 13.4   | 11.4                             | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                        |
-| watchOS 6.0 | 11.0<br>11.1                     | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                 |
-| watchOS 6.1 | 11.2<br>11.2.1<br>11.3<br>11.3.1 | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                 |
-| watchOS 6.2 | 11.4                             | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                 |
+| OS          | Xcode Version                    | Simulators                                                                                                                                                                                                                                                      |
+| ----------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| iOS 13.0    | 11.0                             | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                                                                 |
+| iOS 13.1    | 11.1                             | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                                                                 |
+| iOS 13.2    | 11.2<br>11.2.1                   | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)                                                                 |
+| iOS 13.3    | 11.3<br>11.3.1                   | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad (7th generation)<br>iPad Pro (11-inch)<br>iPad Pro (12.9-inch) (3rd generation)<br>iPad Air (3rd generation)<br>iPad Pro (11-inch) (1st generation) |
+| iOS 13.4    | 11.4                             | iPhone 8<br>iPhone 8 Plus<br>iPhone 11<br>iPhone 11 Pro<br>iPhone 11 Pro Max<br>iPad Pro (9.7-inch)<br>iPad (7th generation)<br>iPad Pro (11-inch) (2nd generation)<br>iPad Pro (12.9-inch) (4th generation)<br>iPad Air (3rd generation)                       |
+| tvOS 13.0   | 11.0<br>11.1                     | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                               |
+| tvOS 13.2   | 11.2<br>11.2.1                   | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                               |
+| tvOS 13.3   | 11.3<br>11.3.1                   | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                               |
+| tvOS 13.4   | 11.4                             | Apple TV<br>Apple TV 4K<br>Apple TV 4K (at 1080p)                                                                                                                                                                                                               |
+| watchOS 6.0 | 11.0<br>11.1                     | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                                                        |
+| watchOS 6.1 | 11.2<br>11.2.1<br>11.3<br>11.3.1 | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                                                        |
+| watchOS 6.2 | 11.4                             | Apple Watch Series 4 - 40mm<br>Apple Watch Series 4 - 44mm<br>Apple Watch Series 5 - 40mm<br>Apple Watch Series 5 - 44mm                                                                                                                                        |
 
 ### Android
 #### Android SDK Tools
@@ -245,7 +255,7 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | cmake            | 3.6.4111459  |
 | lldb             | 3.1.4508709  |
 | ndk-bundle       | 18.1.5063045 |
-| Android Emulator | 30.0.0       |
+| Android Emulator | 30.0.5       |
 
 #### Android Google APIs
 | Package Name                | Description             |
@@ -262,19 +272,3 @@ The following software is installed on machines in the Azure Pipelines **macOS-1
 | Google Play services                            | 49      |
 | Google Repository                               | 58      |
 | Intel x86 Emulator Accelerator (HAXM installer) | 7.5.1   |
-
-## Disk info
-- Total size: 379.8 Gb
-- Free size: 210.72 Gb
-- Used size: 169.09 Gb
-
-## Precache packages
-| Package   | Count | Size    |
-| --------- | ----- | ------- |
-| Nuget     | 759   | 7.57Gb  |
-| CocoaPods | 1432  | 10.47Gb |
-| Carthage  | 134   | 3.8Gb   |
-| Gradle    | 2615  | 5.14Gb  |
-| Maven     | 120   | 0.11Gb  |
-| Npm       | 3621  | 1.08Gb  |
-| Yarn      | 1559  | 1.29Gb  |


### PR DESCRIPTION
## OS X info
- System Version: macOS 10.15.4 (19E266)
- Kernel Version: Darwin 19.4.0

## Installed Software
### Language and Runtime
- Java 14: Zulu14.27+1-CA (build 14+36)
- NVM - Cached node versions: v13.12.0
- .NET SDK 2.0.0 3.0.100 3.0.101 3.0.102 3.0.103 3.1.100 3.1.101 3.1.200 3.1.201
- Go 1.14.1
- PHP 7.4.4
- julia 1.4.0

### Package Management
- Homebrew 2.2.11
- NuGet 5.5.0.6382

### Project Management
- Gradle 6.3
- Git: 2.26.0
- Packer 1.5.5
- GNU parallel 20200322
- gpg (GnuPG) 2.2.20
- helm v3.1.2+gd878d4d
- Docker 19.03.8
- docker-machine 0.16.2
- docker-compose 1.25.4

### Tools
- Fastlane 2.144.0
- Cmake 3.17.0
- App Center CLI 2.3.5
- AWS CLI 2.0.5

### Browsers
- Google Chrome 80.0.3987.149 
- ChromeDriver 80.0.3987.106
- MSEdgeDriver 80.0.361.69

### Xamarin
#### Visual Studio for Mac
- 8.5.0.3183

#### Mono
- 6.8.0.123

#### Xamarin.iOS
- 13.14.1.39

#### Xamarin.Mac
- 6.14.1.39

#### Xamarin.Android
- 10.2.0

### Xcode
| Version          | Build   | Path                           |
| ---------------- | ------- | ------------------------------ |
| 11.4             | 11E146  | /Applications/Xcode_11.4.app   |

#### Android SDK Tools
| Package Name     | Version      |
| ---------------- | ------------ |
| Android Emulator | 30.0.5       |